### PR TITLE
Remove top-level heading.

### DIFF
--- a/cdr/readme.md
+++ b/cdr/readme.md
@@ -1,6 +1,3 @@
-# Gallery Entry: deal.II-cdr
-
-
 ## Overview
 I started this project with the intent of better understanding adaptive mesh
 refinement, parallel computing, and `CMake`. In particular, I started by writing


### PR DESCRIPTION
This is duplicative, and H1-headings in readme.md will conflict with the markup
in the code-gallery pages for this program (which uses H1-headings itself).