### PR TITLE
Remove top-level heading.

### DIFF
--- a/Quasi_static_Finite_strain_Compressible_Elasticity/README.md
+++ b/Quasi_static_Finite_strain_Compressible_Elasticity/README.md
@@ -1,6 +1,3 @@
-# Gallery Entry: deal.II-Quasi-static_Finite_strain_Compressible_Elasticity
-
-
 ## Overview
 The Cook membrane (or cantilever) problem is a classic benchmark test for 
 finite element formulations for solid mechanics. It is typically used to 


### PR DESCRIPTION
This is duplicative, and H1-headings in readme.md will conflict with the markup
in the code-gallery pages for this program (which uses H1-headings itself).