### PR TITLE
Add printable names to each entry.

### DIFF
--- a/ElastoplasticTorsion/doc/entry-name
+++ b/ElastoplasticTorsion/doc/entry-name
@@ -1,0 +1,1 @@
+Elastoplastic Torsion

--- a/Quasi_static_Finite_strain_Compressible_Elasticity/doc/entry-name
+++ b/Quasi_static_Finite_strain_Compressible_Elasticity/doc/entry-name
@@ -1,0 +1,1 @@
+Quasi-Static Finite-Strain Compressible Elasticity

--- a/cdr/doc/entry-name
+++ b/cdr/doc/entry-name
@@ -1,0 +1,1 @@
+Convection Diffusion Reaction


### PR DESCRIPTION
In response to dealii/dealii#2180:

Presently there are three code gallery entries and each one has a slightly different naming convention. This commit adds a 'printable' name to each entry which will make the presentation uniform.

@jppelteret @sfloresm I did my best to guess these names from your contributions. Let me know (or open a PR) if you would like something else.