### PR TITLE
Fix compiler errors and warnings

### DIFF
--- a/CeresFE/support_code/ellipsoid_fit.h
+++ b/CeresFE/support_code/ellipsoid_fit.h
@@ -11,7 +11,6 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/sparse_matrix.h>
-#include <deal.II/lac/compressed_sparsity_pattern.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/grid/tria.h>
@@ -80,14 +79,13 @@ void ellipsoid_fit<dim>::compute_fit(std::vector<double> &ell, unsigned char bou
     std::vector<unsigned int> ind_bnry_col;
 
 	// assemble the sensitivity matrix and r.h.s.
-    double zero_tolerance = 1e-3;
 	for (; cell != endc; ++cell) {
 		if (boundary_that_we_need != 0)
 			cell->set_manifold_id(cell->material_id());
 		for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f) {
 			if (boundary_that_we_need == 0) //if this is the outer surface, then look for boundary ID 0; otherwise look for material ID change.
 					{
-				boundary_ids = cell->face(f)->boundary_indicator();
+				boundary_ids = cell->face(f)->boundary_id();
 				if (boundary_ids == boundary_that_we_need) {
 					for (unsigned int v = 0;
 							v < GeometryInfo<dim>::vertices_per_face; ++v)

--- a/CeresFE/support_code/local_math.h
+++ b/CeresFE/support_code/local_math.h
@@ -11,8 +11,6 @@
 #define PI 3.14159265358979323846
 #define TWOPI 6.283185307179586476925287
 #define SECSINYEAR 3.155692608e+07
-#define MAX(x,y) ((x) > (y)) ? (x) : (y)
-#define MIN(x,y) ((x) < (y)) ? (x) : (y)
 //#define ABS(a) ((a) < 0 ? -(a) : (a))
 
 //double factorial(int n)

--- a/Linear_Elastic_Active_Skeletal_Muscle_Model/Linear_active_muscle_model.cc
+++ b/Linear_Elastic_Active_Skeletal_Muscle_Model/Linear_active_muscle_model.cc
@@ -166,12 +166,12 @@ namespace LMM
       parse_parameters(ParameterHandler &prm);
     };
 
-    void IsotonicContraction::declare_parameters(ParameterHandler &prm)
+    void IsotonicContraction::declare_parameters(ParameterHandler &/*prm*/)
     {
 
     }
 
-    void IsotonicContraction::parse_parameters(ParameterHandler &prm)
+    void IsotonicContraction::parse_parameters(ParameterHandler &/*prm*/)
     {
 
     }
@@ -448,7 +448,7 @@ namespace LMM
 
   template <int dim>
   inline
-  void BodyForce<dim>::vector_value (const Point<dim> &p,
+  void BodyForce<dim>::vector_value (const Point<dim> &/*p*/,
                                      Vector<double>   &values) const
   {
     Assert (values.size() == dim,
@@ -504,7 +504,7 @@ namespace LMM
 
   template <int dim>
   inline
-  void Traction<dim>::vector_value (const Point<dim> &p,
+  void Traction<dim>::vector_value (const Point<dim> &/*p*/,
                                     Vector<double>   &values) const
   {
     Assert (values.size() == dim,
@@ -893,7 +893,7 @@ namespace LMM
     // the muscle
     Point<dim> profile (const Point<dim> &pt_0) const
     {
-      Assert(pt[0] > -1e-6,
+      Assert(pt_0[0] > -1e-6,
              ExcMessage("All points must have x-coordinate > 0"));
 
       const double r_scale = get_radial_scaling_factor(pt_0[0]);
@@ -1148,7 +1148,6 @@ namespace LMM
   {
     const double u = get_neural_signal(time);
 
-    const unsigned int n_cells    = triangulation.n_active_cells();
     const unsigned int n_q_points_cell = qf_cell.size();
     for (unsigned int cell=0; cell<triangulation.n_active_cells(); ++cell)
       {
@@ -1163,7 +1162,6 @@ namespace LMM
   template <int dim>
   void LinearMuscleModelProblem<dim>::update_fibre_state ()
   {
-    const unsigned int n_cells    = triangulation.n_active_cells();
     const unsigned int n_q_points_cell = qf_cell.size();
 
     FEValues<dim> fe_values (fe, qf_cell, update_gradients);
@@ -1245,7 +1243,6 @@ namespace LMM
     const double m_p = fibre.get_m_p();
     const double m_s = fibre.get_m_s();
     const double beta = fibre.get_beta(dt);
-    const double gamma = fibre.get_gamma(dt);
     AssertThrow(beta != 0.0, ExcInternalError());
     const double Cf = T0*(m_p + m_s*(1.0 - m_s/beta));
     const Tensor<1,dim> &M = fibre.get_M();
@@ -1462,7 +1459,6 @@ namespace LMM
           const Point<dim> fixed_point (-parameters.half_length_x,0.0,0.0);
           std::vector<types::global_dof_index> fixed_dof_indices;
           bool found_point_of_interest = false;
-          types::global_dof_index dof_of_interest = numbers::invalid_dof_index;
 
           for (typename DoFHandler<dim>::active_cell_iterator
                cell = dof_handler.begin_active(),
@@ -1519,7 +1515,6 @@ namespace LMM
               const Point<dim> fixed_point (0.0,0.0,0.0);
               std::vector<types::global_dof_index> fixed_dof_indices;
               bool found_point_of_interest = false;
-              types::global_dof_index dof_of_interest = numbers::invalid_dof_index;
 
               for (typename DoFHandler<dim>::active_cell_iterator
                    cell = dof_handler.begin_active(),
@@ -1590,7 +1585,6 @@ namespace LMM
           const Point<dim> roller_point (parameters.axial_length*parameters.scale,0.0,0.0);
           std::vector<types::global_dof_index> fixed_dof_indices;
           bool found_point_of_interest = false;
-          types::global_dof_index dof_of_interest = numbers::invalid_dof_index;
 
           for (typename DoFHandler<dim>::active_cell_iterator
                cell = dof_handler.begin_active(),

--- a/Quasi_static_Finite_strain_Quasi_incompressible_ViscoElasticity/viscoelastic_strip_with_hole.cc
+++ b/Quasi_static_Finite_strain_Quasi_incompressible_ViscoElasticity/viscoelastic_strip_with_hole.cc
@@ -49,7 +49,6 @@
 #include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/lac/solver_selector.h>
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>
-#include <deal.II/lac/trilinos_block_vector.h>
 #include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_sparsity_pattern.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
@@ -295,7 +294,7 @@ namespace ViscoElasStripHole
       prm.enter_subsection("Linear solver");
       {
         prm.declare_entry("Solver type", "cg",
-                          Patterns::Selection(SolverSelector<LA::Vector>::get_solver_names()),
+                          Patterns::Selection(SolverSelector<LA::MPI::Vector>::get_solver_names()),
                           "Type of solver used to solve the linear system");
         prm.declare_entry("Residual", "1e-6",
                           Patterns::Double(0.0),
@@ -512,8 +511,8 @@ namespace ViscoElasStripHole
     }
     void
     update_internal_equilibrium(const Tensor<2, dim> &F,
-                                const double         &p_tilde,
-                                const double         &J_tilde)
+                                const double         &/*p_tilde*/,
+                                const double         &/*J_tilde*/)
     {
       const double det_F = determinant(F);
       const SymmetricTensor<2,dim> C_bar = std::pow(det_F, -2.0 / dim) * Physics::Elasticity::Kinematics::C(F);
@@ -584,7 +583,7 @@ namespace ViscoElasStripHole
              + Physics::Elasticity::StandardTensors<dim>::dev_P * c_bar
              * Physics::Elasticity::StandardTensors<dim>::dev_P;
     }
-    SymmetricTensor<4, dim> get_c_bar(const Tensor<2,dim> &F) const
+    SymmetricTensor<4, dim> get_c_bar(const Tensor<2,dim> &/*F*/) const
     {
       // Elastic Neo-Hookean + Linder2011 eq 56
       return -2.0*mu_v*((time.get_delta_t()/tau_v)/(1.0 + time.get_delta_t()/tau_v))*Physics::Elasticity::StandardTensors<dim>::S;
@@ -643,7 +642,7 @@ namespace ViscoElasStripHole
       material->update_end_timestep();
     }
   private:
-    std_cxx11::shared_ptr< Material_Compressible_Three_Field_Linear_Viscoelastic<dim> > material;
+    std::shared_ptr< Material_Compressible_Three_Field_Linear_Viscoelastic<dim> > material;
   };
   template <int dim>
   class Solid
@@ -896,7 +895,7 @@ namespace ViscoElasStripHole
                 for (unsigned int d=0; d<dim; ++d)
                   {
                     pcout << "Point " << p << " [" << d << "]";
-                    if (!(p == tracked_vertices.size()-1 & d == dim-1))
+                    if (!(p == tracked_vertices.size()-1 && d == dim-1))
                       pcout << ",";
                   }
               }
@@ -912,7 +911,7 @@ namespace ViscoElasStripHole
             for (unsigned int d=0; d<dim; ++d)
               {
                 pcout << tracked_vertices[p][t][d];
-                if (!(p == tracked_vertices.size()-1 & d == dim-1))
+                if (!(p == tracked_vertices.size()-1 && d == dim-1))
                   pcout << ",";
               }
           }

--- a/cdr/common/source/parameters.cc
+++ b/cdr/common/source/parameters.cc
@@ -68,7 +68,7 @@ namespace CDR
     {
       std::ifstream file(file_name);
       configure_parameter_handler(parameter_handler);
-      parameter_handler.read_input(file);
+      parameter_handler.parse_input(file);
     }
 
     parameter_handler.enter_subsection("Geometry");

--- a/two_phase_flow/MultiPhase.cc
+++ b/two_phase_flow/MultiPhase.cc
@@ -67,7 +67,7 @@ public:
 private:
   void set_boundary_inlet();
   void get_boundary_values_U();
-  void get_boundary_values_phi(std::vector<unsigned int> &boundary_values_id_phi,
+  void get_boundary_values_phi(std::vector<types::global_dof_index> &boundary_values_id_phi,
 			       std::vector<double> &boundary_values_phi);
   void output_results();
   void output_vectors();
@@ -109,9 +109,9 @@ private:
   PETScWrappers::MPI::Vector completely_distributed_solution_v;
   PETScWrappers::MPI::Vector completely_distributed_solution_p;
   // BOUNDARY VECTORS
-  std::vector<unsigned int> boundary_values_id_u;
-  std::vector<unsigned int> boundary_values_id_v;
-  std::vector<unsigned int> boundary_values_id_phi;
+  std::vector<types::global_dof_index> boundary_values_id_u;
+  std::vector<types::global_dof_index> boundary_values_id_v;
+  std::vector<types::global_dof_index> boundary_values_id_phi;
   std::vector<double> boundary_values_u;
   std::vector<double> boundary_values_v;
   std::vector<double> boundary_values_phi;
@@ -268,9 +268,9 @@ void MultiPhase<dim>::init_constraints()
 template <int dim>
 void MultiPhase<dim>::get_boundary_values_U()
 {
-  std::map<unsigned int, double> map_boundary_values_u;
-  std::map<unsigned int, double> map_boundary_values_v;
-  std::map<unsigned int, double> map_boundary_values_w;
+  std::map<types::global_dof_index, double> map_boundary_values_u;
+  std::map<types::global_dof_index, double> map_boundary_values_v;
+  std::map<types::global_dof_index, double> map_boundary_values_w;
 
   // NO-SLIP CONDITION 
   if (PROBLEM==BREAKING_DAM || PROBLEM==FALLING_DROP)
@@ -325,8 +325,8 @@ void MultiPhase<dim>::get_boundary_values_U()
   boundary_values_id_v.resize(map_boundary_values_v.size());
   boundary_values_u.resize(map_boundary_values_u.size());
   boundary_values_v.resize(map_boundary_values_v.size());
-  std::map<unsigned int,double>::const_iterator boundary_value_u =map_boundary_values_u.begin();
-  std::map<unsigned int,double>::const_iterator boundary_value_v =map_boundary_values_v.begin();
+  std::map<types::global_dof_index,double>::const_iterator boundary_value_u =map_boundary_values_u.begin();
+  std::map<types::global_dof_index,double>::const_iterator boundary_value_v =map_boundary_values_v.begin();
   
   for (int i=0; boundary_value_u !=map_boundary_values_u.end(); ++boundary_value_u, ++i)
     {
@@ -372,10 +372,10 @@ void MultiPhase<dim>::set_boundary_inlet()
 }
 
 template <int dim>
-void MultiPhase<dim>::get_boundary_values_phi(std::vector<unsigned int> &boundary_values_id_phi,
+void MultiPhase<dim>::get_boundary_values_phi(std::vector<types::global_dof_index> &boundary_values_id_phi,
 					      std::vector<double> &boundary_values_phi)
 {
-  std::map<unsigned int, double> map_boundary_values_phi;
+  std::map<types::global_dof_index, double> map_boundary_values_phi;
   unsigned int boundary_id=0;
   
   set_boundary_inlet();
@@ -383,7 +383,7 @@ void MultiPhase<dim>::get_boundary_values_phi(std::vector<unsigned int> &boundar
   VectorTools::interpolate_boundary_values (dof_handler_LS,boundary_id,BoundaryPhi<dim>(1.0),map_boundary_values_phi);
   boundary_values_id_phi.resize(map_boundary_values_phi.size());
   boundary_values_phi.resize(map_boundary_values_phi.size());  
-  std::map<unsigned int,double>::const_iterator boundary_value_phi = map_boundary_values_phi.begin();
+  std::map<types::global_dof_index,double>::const_iterator boundary_value_phi = map_boundary_values_phi.begin();
   for (int i=0; boundary_value_phi !=map_boundary_values_phi.end(); ++boundary_value_phi, ++i)
     {
       boundary_values_id_phi[i]=boundary_value_phi->first;

--- a/two_phase_flow/NavierStokesSolver.cc
+++ b/two_phase_flow/NavierStokesSolver.cc
@@ -84,12 +84,12 @@ public:
 			 PETScWrappers::MPI::Vector locally_relevant_solution_w,
 			 PETScWrappers::MPI::Vector locally_relevant_solution_p);
   //boundary conditions
-  void set_boundary_conditions(std::vector<unsigned int> boundary_values_id_u,
-			       std::vector<unsigned int> boundary_values_id_v, std::vector<double> boundary_values_u,
+  void set_boundary_conditions(std::vector<types::global_dof_index> boundary_values_id_u,
+			       std::vector<types::global_dof_index> boundary_values_id_v, std::vector<double> boundary_values_u,
 			       std::vector<double> boundary_values_v);
-  void set_boundary_conditions(std::vector<unsigned int> boundary_values_id_u,
-			       std::vector<unsigned int> boundary_values_id_v,
-			       std::vector<unsigned int> boundary_values_id_w, std::vector<double> boundary_values_u,
+  void set_boundary_conditions(std::vector<types::global_dof_index> boundary_values_id_u,
+			       std::vector<types::global_dof_index> boundary_values_id_v,
+			       std::vector<types::global_dof_index> boundary_values_id_w, std::vector<double> boundary_values_u,
 			       std::vector<double> boundary_values_v, std::vector<double> boundary_values_w);
   void set_velocity(PETScWrappers::MPI::Vector locally_relevant_solution_u,
 		    PETScWrappers::MPI::Vector locally_relevant_solution_v);
@@ -184,9 +184,9 @@ private:
   ConstraintMatrix constraints;
   ConstraintMatrix constraints_psi;
 
-  std::vector<unsigned int> boundary_values_id_u;
-  std::vector<unsigned int> boundary_values_id_v;
-  std::vector<unsigned int> boundary_values_id_w;
+  std::vector<types::global_dof_index> boundary_values_id_u;
+  std::vector<types::global_dof_index> boundary_values_id_v;
+  std::vector<types::global_dof_index> boundary_values_id_w;
   std::vector<double> boundary_values_u;
   std::vector<double> boundary_values_v;
   std::vector<double> boundary_values_w;
@@ -357,8 +357,8 @@ void NavierStokesSolver<dim>::initial_condition(PETScWrappers::MPI::Vector local
 }
 
 template<int dim>
-void NavierStokesSolver<dim>::set_boundary_conditions(std::vector<unsigned int> boundary_values_id_u,
-						      std::vector<unsigned int> boundary_values_id_v, 
+void NavierStokesSolver<dim>::set_boundary_conditions(std::vector<types::global_dof_index> boundary_values_id_u,
+						      std::vector<types::global_dof_index> boundary_values_id_v, 
 						      std::vector<double> boundary_values_u,
 						      std::vector<double> boundary_values_v) 
 {
@@ -369,9 +369,9 @@ void NavierStokesSolver<dim>::set_boundary_conditions(std::vector<unsigned int> 
 }
 
 template<int dim>
-void NavierStokesSolver<dim>::set_boundary_conditions(std::vector<unsigned int> boundary_values_id_u,
-						      std::vector<unsigned int> boundary_values_id_v,
-						      std::vector<unsigned int> boundary_values_id_w, 
+void NavierStokesSolver<dim>::set_boundary_conditions(std::vector<types::global_dof_index> boundary_values_id_u,
+						      std::vector<types::global_dof_index> boundary_values_id_v,
+						      std::vector<types::global_dof_index> boundary_values_id_w, 
 						      std::vector<double> boundary_values_u,
 						      std::vector<double> boundary_values_v, 
 						      std::vector<double> boundary_values_w) 
@@ -641,7 +641,7 @@ void NavierStokesSolver<dim>::assemble_system_U()
   std::vector<Tensor<1, dim> > grad_psiqn(n_q_points);
   std::vector<Tensor<1, dim> > grad_psiqnm1(n_q_points);
   
-  std::vector<unsigned int> local_dof_indices(dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
   std::vector<Tensor<1, dim> > shape_grad(dofs_per_cell);
   std::vector<double> shape_value(dofs_per_cell);
   
@@ -868,7 +868,7 @@ void NavierStokesSolver<dim>::assemble_system_dpsi_q() {
   std::vector<Tensor<1, dim> > gvnp1(n_q_points);
   std::vector<Tensor<1, dim> > gwnp1(n_q_points);
 
-  std::vector<unsigned int> local_dof_indices(dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
   std::vector<double> shape_value(dofs_per_cell);
   std::vector<Tensor<1, dim> > shape_grad(dofs_per_cell);
 
@@ -913,7 +913,7 @@ void NavierStokesSolver<dim>::assemble_system_dpsi_q() {
 	for (unsigned int i=0; i<dofs_per_cell; ++i) {
 	  cell_rhs_psi(i)+=-3./2./time_step*rho_min*divU*shape_value[i]*JxW;
 	  cell_rhs_q(i)-=nu_value*divU*shape_value[i]*JxW;
-	  if (rebuild_S_M==true)
+	  if (rebuild_S_M==true) {
 	    for (unsigned int j=0; j<dofs_per_cell; ++j) 
 	      if (i==j)
 		{
@@ -925,6 +925,7 @@ void NavierStokesSolver<dim>::assemble_system_dpsi_q() {
 		  cell_S(i,j)+=shape_grad[i]*shape_grad[j]*JxW;
 		  cell_M(i,j)+=shape_value[i]*shape_value[j]*JxW;
 		}
+      }
 	}
       }
       cell_P->get_dof_indices(local_dof_indices);


### PR DESCRIPTION
This fixes all the compiler error and warnings for me compiling with 64-bit indices and a recent developer version. Fixes dealii/dealii#6030.

Admittedly, the indentation looks weird since some of the programs use tabs for indenting. Maybe we should just run our indenting script also for the code gallery.