### PR TITLE
Fix a bug in the Metropolis-Hastings solver.

### DIFF
--- a/MCMC-Laplace/mcmc-laplace.cc
+++ b/MCMC-Laplace/mcmc-laplace.cc
@@ -842,7 +842,7 @@ int main()
   LogLikelihood::Gaussian        log_likelihood(exact_solution, 0.05);
   LogPrior::LogGaussian          log_prior(0, 2);
   ProposalGenerator::LogGaussian proposal_generator(
-    random_seed, 0.0725); /* so that the acceptance ratio is ~0.3 */
+    random_seed, 0.09); /* so that the acceptance ratio is ~0.24 */
   Sampler::MetropolisHastings sampler(laplace_problem,
                                       log_likelihood,
                                       log_prior,

--- a/MCMC-Laplace/mcmc-laplace.cc
+++ b/MCMC-Laplace/mcmc-laplace.cc
@@ -571,7 +571,7 @@ namespace ProposalGenerator
 // The last main class is the Metropolis-Hastings sampler itself.
 // If you understand the algorithm behind this method, then
 // the following implementation should not be too difficult
-// to understand. The only thing of relevance is that descriptions
+// to read. The only thing of relevance is that descriptions
 // of the algorithm typically ask whether the *ratio* of two
 // probabilities (the "posterior" probabilities of the current
 // and the previous samples, where the "posterior" is the product of the
@@ -580,7 +580,12 @@ namespace ProposalGenerator
 // *logarithms* of these probabilities, we now need to take
 // the ratio of appropriate exponentials -- which is made numerically
 // more stable by considering the exponential of the difference of
-// the log probabilities.
+// the log probabilities. The only other slight complication is that
+// we need to multiply this ratio by the ratio of proposal probabilities
+// since we use a non-symmetric proposal distribution. This makes the
+// formula for accepting a sample slightly more awkward, but if you
+// take exponentials on both sides of the comparison, the formula
+// should become obvious again.
 namespace Sampler
 {
   class MetropolisHastings

--- a/MCMC-Laplace/mcmc-laplace.cc
+++ b/MCMC-Laplace/mcmc-laplace.cc
@@ -582,10 +582,7 @@ namespace ProposalGenerator
 // more stable by considering the exponential of the difference of
 // the log probabilities. The only other slight complication is that
 // we need to multiply this ratio by the ratio of proposal probabilities
-// since we use a non-symmetric proposal distribution. This makes the
-// formula for accepting a sample slightly more awkward, but if you
-// take exponentials on both sides of the comparison, the formula
-// should become obvious again.
+// since we use a non-symmetric proposal distribution.
 //
 // Finally, we note that the output is generated with 7 digits of
 // accuracy. (The C++ default is 6 digits.) We do this because,
@@ -672,14 +669,9 @@ namespace Sampler
           (likelihood.log_likelihood(simulator.evaluate(trial_sample)) +
            prior.log_prior(trial_sample));
 
-        if ((trial_log_posterior + std::log(perturbation_probability_ratio)
-             >=
-             current_log_posterior)
-            ||
-            (std::exp(trial_log_posterior - current_log_posterior)
-             * perturbation_probability_ratio
-             >=
-             uniform_distribution(random_number_generator)))
+        if (std::exp(trial_log_posterior - current_log_posterior) * perturbation_probability_ratio
+            >=
+            uniform_distribution(random_number_generator))
           {
             current_sample        = trial_sample;
             current_log_posterior = trial_log_posterior;

--- a/MCMC-Laplace/mcmc-laplace.cc
+++ b/MCMC-Laplace/mcmc-laplace.cc
@@ -586,6 +586,13 @@ namespace ProposalGenerator
 // formula for accepting a sample slightly more awkward, but if you
 // take exponentials on both sides of the comparison, the formula
 // should become obvious again.
+//
+// Finally, we note that the output is generated with 7 digits of
+// accuracy. (The C++ default is 6 digits.) We do this because,
+// as shown in the paper, we can determine the mean value of the
+// probability distribution we are sampling here to at least six
+// digits of accuracy, and do not want to be limited by the precision
+// of the output.
 namespace Sampler
 {
   class MetropolisHastings
@@ -634,6 +641,8 @@ namespace Sampler
     , accepted_sample_number(0)
   {
     output_file.open("samples-" + dataset_name + ".txt");
+    output_file.precision(7);
+
     random_number_generator.seed(random_seed);
   }
 

--- a/MCMC-Laplace/mcmc-laplace.cc
+++ b/MCMC-Laplace/mcmc-laplace.cc
@@ -745,7 +745,7 @@ int main()
   MultithreadInfo::set_thread_limit(1);
 
   const unsigned int random_seed  = (testing ? 1U : std::random_device()());
-  const std::string  dataset_name = std::to_string(random_seed);
+  const std::string  dataset_name = Utilities::to_string(random_seed, 10);
 
   const Vector<double> exact_solution(
     {   0.06076511762259369, 0.09601910120848481, 

--- a/MCMC-Laplace/mcmc-laplace.cc
+++ b/MCMC-Laplace/mcmc-laplace.cc
@@ -856,6 +856,6 @@ int main()
   sampler.sample(starting_coefficients,
                  (testing ? 250 * 40 /* takes 40 seconds */
                             :
-                            250 * 60 * 60 * 24 * 30 /* takes a month */
+                            100000000 /* takes 6 days */
                   ));
 }


### PR DESCRIPTION
This is rather a big nuisance: I created 10^11 samples with the existing program, burning ~15 CPU years. But it turns out that these samples can all go into the trash: The sampling algorithm had a subtle bug :-(