### PR TITLE
UMFPACK is no longer required.

### DIFF
--- a/MCMC-Laplace/CMakeLists.txt
+++ b/MCMC-Laplace/CMakeLists.txt
@@ -19,18 +19,6 @@ ENDIF()
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 PROJECT("mcmc-laplace")
 
-#
-# Are all dependencies fullfilled?
-#
-
-IF(NOT DEAL_II_WITH_UMFPACK)
-  MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
-    DEAL_II_WITH_UMFPACK = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
-    )
-ENDIF()
-
 
 #
 # Set up program:


### PR DESCRIPTION
Since #98, the MCMC-Laplace program no longer actually requires UMFPACK. Remove the dependency.

/rebuild