### PR TITLE
Use the non-deprecated name of a class.

### DIFF
--- a/parallel_in_time/src/HeatEquationImplem.hh
+++ b/parallel_in_time/src/HeatEquationImplem.hh
@@ -334,7 +334,7 @@ HeatEquation<dim>::process_solution(double a_time,
                                                             difference_per_cell,
                                                             VectorTools::H1_seminorm);
 
-  const QTrapez<1> q_trapez;
+  const QTrapezoid<1> q_trapez;
   const QIterated<dim> q_iterated (q_trapez, 5);
   VectorTools::integrate_difference (dof_handler,
                                      a_vector,


### PR DESCRIPTION
Fixes #123.