### PR TITLE
Add a missing #include file.

### DIFF
--- a/MCMC-Laplace/mcmc-laplace.cc
+++ b/MCMC-Laplace/mcmc-laplace.cc
@@ -20,6 +20,7 @@
 
 
 #include <deal.II/base/timer.h>
+#include <deal.II/base/multithread_info.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/grid_generator.h>


### PR DESCRIPTION
Apparently it is now necessary with the current master branch of deal.II.