### PR TITLE
Fix a missing include file.

### DIFF
--- a/information_based_mesh_refinement/mesh_refinement.cc
+++ b/information_based_mesh_refinement/mesh_refinement.cc
@@ -19,6 +19,7 @@
 
 
 #include <deal.II/base/numbers.h>
+#include <deal.II/base/thread_management.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/grid_generator.h>


### PR DESCRIPTION
This was apparently caused by some recent cleanup in the library where the necessary file is no longer transitively included.