### PR TITLE
Mark all overridden functions with 'override'.

### DIFF
--- a/Distributed_LDG_Method/Functions.cc
+++ b/Distributed_LDG_Method/Functions.cc
@@ -18,7 +18,7 @@ public:
   {}
 
   virtual double value(const Point<dim> &p,
-                       const unsigned int component = 0 ) const;
+                       const unsigned int component = 0 ) const override;
 };
 
 template <int dim>
@@ -29,7 +29,7 @@ public:
   {}
 
   virtual double value(const Point<dim> &p,
-                       const unsigned int component = 0 ) const;
+                       const unsigned int component = 0 ) const override;
 };
 
 template<int dim>
@@ -40,7 +40,7 @@ public:
   {}
 
   virtual void vector_value(const Point<dim> &p,
-                            Vector<double> &valuess) const;
+                            Vector<double> &valuess) const override;
 };
 
 template <int dim>

--- a/ElastoplasticTorsion/ElastoplasticTorsion.cc
+++ b/ElastoplasticTorsion/ElastoplasticTorsion.cc
@@ -186,8 +186,8 @@ namespace nsp
   {
   public:
     Solution () : Function<dim>() {}
-    virtual double value (const Point<dim> &pto, const unsigned int component = 0) const;
-    virtual Tensor<1,dim> gradient (const Point<dim> &pto, const unsigned int component = 0) const;
+    virtual double value (const Point<dim> &pto, const unsigned int component = 0) const override;
+    virtual Tensor<1,dim> gradient (const Point<dim> &pto, const unsigned int component = 0) const override;
   };
 
   template <int dim>
@@ -237,12 +237,13 @@ namespace nsp
       std::vector< Vector< double > > &
     ) const;
 
-    virtual std::vector<std::string> get_names () const;
+    virtual std::vector<std::string> get_names () const override;
 
     virtual
     std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    get_data_component_interpretation () const;
-    virtual UpdateFlags get_needed_update_flags () const;
+    get_data_component_interpretation () const override;
+
+    virtual UpdateFlags get_needed_update_flags () const override;
   };
 
 
@@ -385,7 +386,7 @@ namespace nsp
     BoundaryValues () : Function<dim>() {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int  component = 0) const;
+                          const unsigned int  component = 0) const override;
   };
 
 
@@ -426,7 +427,7 @@ namespace nsp
   public:
     RightHandSide () : Function<dim>() {}
     virtual double value (const Point<dim> &p,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
   };
 
   template <int dim>

--- a/Linear_Elastic_Active_Skeletal_Muscle_Model/Linear_active_muscle_model.cc
+++ b/Linear_Elastic_Active_Skeletal_Muscle_Model/Linear_active_muscle_model.cc
@@ -421,10 +421,10 @@ namespace LMM
     virtual ~BodyForce () {}
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &values) const;
+                               Vector<double>   &values) const override;
 
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> >   &value_list) const;
+                                    std::vector<Vector<double> >   &value_list) const override;
 
     const double rho;
     const double g;
@@ -483,10 +483,10 @@ namespace LMM
     virtual ~Traction () {}
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double>   &values) const;
+                               Vector<double>   &values) const override;
 
     virtual void vector_value_list (const std::vector<Point<dim> > &points,
-                                    std::vector<Vector<double> >   &value_list) const;
+                                    std::vector<Vector<double> >   &value_list) const override;
 
     const double t;
   };

--- a/MultipointFluxMixedFiniteElementMethods/data.h
+++ b/MultipointFluxMixedFiniteElementMethods/data.h
@@ -31,7 +31,7 @@ namespace MFMFE
     RightHandSide () : Function<dim>(1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
   };
 
   template <int dim>
@@ -62,7 +62,7 @@ namespace MFMFE
     PressureBoundaryValues () : Function<dim>(1) {}
 
     virtual double value (const Point<dim>   &p,
-                          const unsigned int component = 0) const;
+                          const unsigned int component = 0) const override;
   };
 
   template <int dim>
@@ -90,10 +90,10 @@ namespace MFMFE
     ExactSolution () : Function<dim>(dim+1) {}
 
     virtual void vector_value (const Point<dim> &p,
-                               Vector<double> &value) const;
+                               Vector<double> &value) const override;
 
     virtual void vector_gradient (const Point<dim> &p,
-                                  std::vector<Tensor<1,dim,double>>  &grads) const;
+                                  std::vector<Tensor<1,dim,double>>  &grads) const override;
   };
 
   template <int dim>
@@ -158,7 +158,7 @@ namespace MFMFE
     KInverse () : TensorFunction<2,dim>() {}
 
     virtual void value_list (const std::vector<Point<dim> > &points,
-                             std::vector<Tensor<2,dim> >    &values) const;
+                             std::vector<Tensor<2,dim> >    &values) const override;
   };
 
   template <int dim>

--- a/Nonlinear_PoroViscoelasticity/nonlinear-poro-viscoelasticity.cc
+++ b/Nonlinear_PoroViscoelasticity/nonlinear-poro-viscoelasticity.cc
@@ -806,7 +806,7 @@ namespace NonLinearPoroViscoElasticity
           {}
 
            double
-           get_viscous_dissipation() const
+           get_viscous_dissipation() const override
            {
                return 0.0;
            }
@@ -815,7 +815,7 @@ namespace NonLinearPoroViscoElasticity
           const double mu;
 
           SymmetricTensor<2, dim, NumberType>
-          get_tau_E_base(const Tensor<2,dim, NumberType> &F) const
+          get_tau_E_base(const Tensor<2,dim, NumberType> &F) const override
           {
              static const SymmetricTensor< 2, dim, double>
                 I (Physics::Elasticity::StandardTensors<dim>::I);
@@ -864,7 +864,7 @@ namespace NonLinearPoroViscoElasticity
           {}
 
            double
-           get_viscous_dissipation() const
+           get_viscous_dissipation() const override
            {
                return 0.0;
            }
@@ -874,7 +874,7 @@ namespace NonLinearPoroViscoElasticity
           std::vector<double> alpha;
 
           SymmetricTensor<2, dim, NumberType>
-          get_tau_E_base(const Tensor<2,dim, NumberType> &F) const
+          get_tau_E_base(const Tensor<2,dim, NumberType> &F) const override
           {
             const SymmetricTensor<2, dim, NumberType>
              B = symmetrize(F * transpose(F));
@@ -936,7 +936,7 @@ namespace NonLinearPoroViscoElasticity
             {}
 
           void
-          update_internal_equilibrium( const Tensor<2, dim, NumberType> &F )
+          update_internal_equilibrium( const Tensor<2, dim, NumberType> &F ) override
           {
               Material_Hyperelastic < dim, NumberType >::update_internal_equilibrium(F);
 
@@ -1048,13 +1048,13 @@ namespace NonLinearPoroViscoElasticity
                       this->Cinv_v_1[a][b]= Tensor<0,dim,double>(Cinv_v_1_AD[a][b]);
           }
 
-          void update_end_timestep()
+          void update_end_timestep() override
           {
               Material_Hyperelastic < dim, NumberType >::update_end_timestep();
               this->Cinv_v_1_converged = this->Cinv_v_1;
           }
 
-           double get_viscous_dissipation() const
+           double get_viscous_dissipation() const override
            {
                NumberType dissipation_term = get_tau_E_neq() * get_tau_E_neq(); //Double contract the two SymmetricTensor
                dissipation_term /= (2*viscosity_mode_1);
@@ -1073,7 +1073,7 @@ namespace NonLinearPoroViscoElasticity
           SymmetricTensor<2, dim, NumberType> tau_neq_1;
 
           SymmetricTensor<2, dim, NumberType>
-          get_tau_E_base(const Tensor<2,dim, NumberType> &F) const
+          get_tau_E_base(const Tensor<2,dim, NumberType> &F) const override
           {
               return ( get_tau_E_neq() + get_tau_E_eq(F) );
           }
@@ -2813,7 +2813,7 @@ namespace NonLinearPoroViscoElasticity
           virtual void
           evaluate_vector_field
                (const DataPostprocessorInputs::Vector<dim> &input_data,
-                std::vector<Vector<double> >               &computed_quantities) const
+                std::vector<Vector<double> >               &computed_quantities) const override
           {
             AssertDimension (input_data.solution_gradients.size(),
                              computed_quantities.size());
@@ -3925,7 +3925,7 @@ namespace NonLinearPoroViscoElasticity
           virtual ~VerificationEhlers1999TubeBase () {}
 
         private:
-          virtual void make_grid()
+          virtual void make_grid() override
           {
             GridGenerator::cylinder( this->triangulation,
                                      0.1,
@@ -3942,7 +3942,7 @@ namespace NonLinearPoroViscoElasticity
             this->triangulation.reset_manifold(0);
           }
 
-          virtual void define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices)
+          virtual void define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices) override
           {
             tracked_vertices[0][0] = 0.0*this->parameters.scale;
             tracked_vertices[0][1] = 0.0*this->parameters.scale;
@@ -3953,7 +3953,7 @@ namespace NonLinearPoroViscoElasticity
             tracked_vertices[1][2] = -0.5*this->parameters.scale;
           }
 
-          virtual void make_dirichlet_constraints(AffineConstraints<double> &constraints)
+          virtual void make_dirichlet_constraints(AffineConstraints<double> &constraints) override
           {
             if (this->time.get_timestep() < 2)
             {
@@ -3990,7 +3990,7 @@ namespace NonLinearPoroViscoElasticity
 
           virtual double
           get_prescribed_fluid_flow (const types::boundary_id &boundary_id,
-                                     const Point<dim>         &pt) const
+                                     const Point<dim>         &pt) const override
           {
               (void)pt;
               (void)boundary_id;
@@ -3998,20 +3998,20 @@ namespace NonLinearPoroViscoElasticity
           }
 
           virtual types::boundary_id
-          get_reaction_boundary_id_for_output() const
+          get_reaction_boundary_id_for_output() const override
           {
               return 2;
           }
 
           virtual  std::pair<types::boundary_id,types::boundary_id>
-          get_drained_boundary_id_for_output() const
+          get_drained_boundary_id_for_output() const override
           {
               return std::make_pair(2,2);
           }
 
           virtual std::vector<double>
           get_dirichlet_load(const types::boundary_id   &boundary_id,
-                             const int                  &direction) const
+                             const int                  &direction) const override
           {
               std::vector<double> displ_incr(dim, 0.0);
               (void)boundary_id;
@@ -4038,7 +4038,7 @@ namespace NonLinearPoroViscoElasticity
             virtual Tensor<1,dim>
             get_neumann_traction (const types::boundary_id &boundary_id,
                                   const Point<dim>         &pt,
-                                  const Tensor<1,dim>      &N) const
+                                  const Tensor<1,dim>      &N) const override
             {
               if (this->parameters.load_type == "pressure")
               {
@@ -4070,7 +4070,7 @@ namespace NonLinearPoroViscoElasticity
             virtual Tensor<1,dim>
             get_neumann_traction (const types::boundary_id &boundary_id,
                                   const Point<dim>         &pt,
-                                  const Tensor<1,dim>      &N) const
+                                  const Tensor<1,dim>      &N) const override
             {
               if (this->parameters.load_type == "pressure")
               {
@@ -4106,7 +4106,7 @@ namespace NonLinearPoroViscoElasticity
 
         private:
           virtual void
-          make_grid()
+          make_grid() override
           {
              GridGenerator::hyper_rectangle(this->triangulation,
                                             Point<dim>(0.0, 0.0, 0.0),
@@ -4134,7 +4134,7 @@ namespace NonLinearPoroViscoElasticity
           }
 
           virtual void
-          define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices)
+          define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices) override
           {
             tracked_vertices[0][0] = 0.0*this->parameters.scale;
             tracked_vertices[0][1] = 0.0*this->parameters.scale;
@@ -4146,7 +4146,7 @@ namespace NonLinearPoroViscoElasticity
           }
 
           virtual void
-          make_dirichlet_constraints(AffineConstraints<double> &constraints)
+          make_dirichlet_constraints(AffineConstraints<double> &constraints) override
           {
             if (this->time.get_timestep() < 2)
             {
@@ -4201,7 +4201,7 @@ namespace NonLinearPoroViscoElasticity
           virtual Tensor<1,dim>
           get_neumann_traction (const types::boundary_id &boundary_id,
                                 const Point<dim>         &pt,
-                                const Tensor<1,dim>      &N) const
+                                const Tensor<1,dim>      &N) const override
           {
             if (this->parameters.load_type == "pressure")
             {
@@ -4218,7 +4218,7 @@ namespace NonLinearPoroViscoElasticity
 
           virtual double
           get_prescribed_fluid_flow (const types::boundary_id &boundary_id,
-                                     const Point<dim>         &pt) const
+                                     const Point<dim>         &pt) const override
           {
               (void)pt;
               (void)boundary_id;
@@ -4226,20 +4226,20 @@ namespace NonLinearPoroViscoElasticity
           }
 
           virtual types::boundary_id
-          get_reaction_boundary_id_for_output() const
+          get_reaction_boundary_id_for_output() const override
           {
               return 100;
           }
 
           virtual  std::pair<types::boundary_id,types::boundary_id>
-          get_drained_boundary_id_for_output() const
+          get_drained_boundary_id_for_output() const override
           {
               return std::make_pair(101,101);
           }
 
           virtual std::vector<double>
           get_dirichlet_load(const types::boundary_id   &boundary_id,
-                             const int                  &direction) const
+                             const int                  &direction) const override
           {
               std::vector<double> displ_incr(dim, 0.0);
               (void)boundary_id;
@@ -4263,7 +4263,7 @@ namespace NonLinearPoroViscoElasticity
           virtual ~Franceschini2006Consolidation () {}
 
         private:
-          virtual void make_grid()
+          virtual void make_grid() override
           {
             const Point<dim-1> mesh_center(0.0, 0.0);
             const double radius = 0.5;
@@ -4310,7 +4310,7 @@ namespace NonLinearPoroViscoElasticity
             this->triangulation.refine_global(std::max (1U, this->parameters.global_refinement));
           }
 
-          virtual void define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices)
+          virtual void define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices) override
           {
             tracked_vertices[0][0] = 0.0*this->parameters.scale;
             tracked_vertices[0][1] = 0.0*this->parameters.scale;
@@ -4322,7 +4322,7 @@ namespace NonLinearPoroViscoElasticity
             tracked_vertices[1][2] = 0.0*this->parameters.scale;
           }
 
-          virtual void make_dirichlet_constraints(AffineConstraints<double> &constraints)
+          virtual void make_dirichlet_constraints(AffineConstraints<double> &constraints) override
           {
             if (this->time.get_timestep() < 2)
             {
@@ -4378,7 +4378,7 @@ namespace NonLinearPoroViscoElasticity
 
           virtual double
           get_prescribed_fluid_flow (const types::boundary_id &boundary_id,
-                                     const Point<dim>         &pt) const
+                                     const Point<dim>         &pt) const override
           {
               (void)pt;
               (void)boundary_id;
@@ -4386,20 +4386,20 @@ namespace NonLinearPoroViscoElasticity
           }
 
           virtual types::boundary_id
-          get_reaction_boundary_id_for_output() const
+          get_reaction_boundary_id_for_output() const override
           {
               return 2;
           }
 
           virtual  std::pair<types::boundary_id,types::boundary_id>
-          get_drained_boundary_id_for_output() const
+          get_drained_boundary_id_for_output() const override
           {
               return std::make_pair(1,2);
           }
 
           virtual std::vector<double>
           get_dirichlet_load(const types::boundary_id   &boundary_id,
-                             const int                  &direction) const
+                             const int                  &direction) const override
           {
               std::vector<double> displ_incr(dim, 0.0);
               (void)boundary_id;
@@ -4412,7 +4412,7 @@ namespace NonLinearPoroViscoElasticity
           virtual Tensor<1,dim>
           get_neumann_traction (const types::boundary_id &boundary_id,
                                 const Point<dim>         &pt,
-                                const Tensor<1,dim>      &N) const
+                                const Tensor<1,dim>      &N) const override
           {
             if (this->parameters.load_type == "pressure")
             {
@@ -4459,7 +4459,7 @@ namespace NonLinearPoroViscoElasticity
 
         private:
           virtual void
-          make_grid()
+          make_grid() override
           {
             GridGenerator::hyper_cube(this->triangulation,
                                       0.0,
@@ -4487,7 +4487,7 @@ namespace NonLinearPoroViscoElasticity
 
           virtual double
           get_prescribed_fluid_flow (const types::boundary_id &boundary_id,
-                                     const Point<dim>         &pt) const
+                                     const Point<dim>         &pt) const override
           {
               (void)pt;
               (void)boundary_id;
@@ -4495,7 +4495,7 @@ namespace NonLinearPoroViscoElasticity
           }
 
           virtual  std::pair<types::boundary_id,types::boundary_id>
-          get_drained_boundary_id_for_output() const
+          get_drained_boundary_id_for_output() const override
           {
               return std::make_pair(100,100);
           }
@@ -4515,7 +4515,7 @@ namespace NonLinearPoroViscoElasticity
 
         private:
           virtual void
-          define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices)
+          define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices) override
           {
             tracked_vertices[0][0] = 0.5*this->parameters.scale;
             tracked_vertices[0][1] = 0.5*this->parameters.scale;
@@ -4527,7 +4527,7 @@ namespace NonLinearPoroViscoElasticity
           }
 
           virtual void
-          make_dirichlet_constraints(AffineConstraints<double> &constraints)
+          make_dirichlet_constraints(AffineConstraints<double> &constraints) override
           {
               if (this->time.get_timestep() < 2)
               {
@@ -4583,7 +4583,7 @@ namespace NonLinearPoroViscoElasticity
           virtual Tensor<1,dim>
           get_neumann_traction (const types::boundary_id &boundary_id,
                                 const Point<dim>         &pt,
-                                const Tensor<1,dim>      &N) const
+                                const Tensor<1,dim>      &N) const override
           {
               if (this->parameters.load_type == "pressure")
               {
@@ -4604,14 +4604,14 @@ namespace NonLinearPoroViscoElasticity
             }
 
           virtual types::boundary_id
-          get_reaction_boundary_id_for_output() const
+          get_reaction_boundary_id_for_output() const override
           {
               return 5;
           }
 
           virtual std::vector<double>
           get_dirichlet_load(const types::boundary_id   &boundary_id,
-                             const int                  &direction) const
+                             const int                  &direction) const override
           {
                 std::vector<double> displ_incr(dim,0.0);
 
@@ -4671,7 +4671,7 @@ namespace NonLinearPoroViscoElasticity
 
         private:
           virtual void
-          define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices)
+          define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices) override
           {
             tracked_vertices[0][0] = 0.5*this->parameters.scale;
             tracked_vertices[0][1] = 0.5*this->parameters.scale;
@@ -4683,7 +4683,7 @@ namespace NonLinearPoroViscoElasticity
           }
 
           virtual void
-          make_dirichlet_constraints(AffineConstraints<double> &constraints)
+          make_dirichlet_constraints(AffineConstraints<double> &constraints) override
           {
               if (this->time.get_timestep() < 2)
               {
@@ -4735,7 +4735,7 @@ namespace NonLinearPoroViscoElasticity
           virtual Tensor<1,dim>
           get_neumann_traction (const types::boundary_id &boundary_id,
                                 const Point<dim>         &pt,
-                                const Tensor<1,dim>      &N) const
+                                const Tensor<1,dim>      &N) const override
           {
               if (this->parameters.load_type == "pressure")
               {
@@ -4756,14 +4756,14 @@ namespace NonLinearPoroViscoElasticity
             }
 
           virtual types::boundary_id
-          get_reaction_boundary_id_for_output() const
+          get_reaction_boundary_id_for_output() const override
           {
               return 5;
           }
 
           virtual std::vector<double>
           get_dirichlet_load(const types::boundary_id   &boundary_id,
-                             const int                  &direction) const
+                             const int                  &direction) const override
           {
                 std::vector<double> displ_incr(dim,0.0);
 
@@ -4821,7 +4821,7 @@ namespace NonLinearPoroViscoElasticity
 
         private:
           virtual void
-          define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices)
+          define_tracked_vertices(std::vector<Point<dim> > &tracked_vertices) override
           {
             tracked_vertices[0][0] = 0.75*this->parameters.scale;
             tracked_vertices[0][1] = 0.5*this->parameters.scale;
@@ -4833,7 +4833,7 @@ namespace NonLinearPoroViscoElasticity
           }
 
           virtual void
-          make_dirichlet_constraints(AffineConstraints<double> &constraints)
+          make_dirichlet_constraints(AffineConstraints<double> &constraints) override
           {
               if (this->time.get_timestep() < 2)
               {
@@ -4885,7 +4885,7 @@ namespace NonLinearPoroViscoElasticity
           virtual Tensor<1,dim>
           get_neumann_traction (const types::boundary_id &boundary_id,
                                 const Point<dim>         &pt,
-                                const Tensor<1,dim>      &N) const
+                                const Tensor<1,dim>      &N) const override
           {
               if (this->parameters.load_type == "pressure")
               {
@@ -4909,14 +4909,14 @@ namespace NonLinearPoroViscoElasticity
             }
 
           virtual types::boundary_id
-          get_reaction_boundary_id_for_output() const
+          get_reaction_boundary_id_for_output() const override
           {
               return 4;
           }
 
           virtual std::vector<double>
           get_dirichlet_load(const types::boundary_id   &boundary_id,
-                             const int                  &direction) const
+                             const int                  &direction) const override
           {
                 std::vector<double> displ_incr (dim, 0.0);
 

--- a/Quasi_static_Finite_strain_Compressible_Elasticity/cook_membrane.cc
+++ b/Quasi_static_Finite_strain_Compressible_Elasticity/cook_membrane.cc
@@ -1692,7 +1692,7 @@ namespace Cook_Membrane
     virtual void
     assemble_system_tangent_residual_one_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
                                               ScratchData_ASM &scratch,
-                                              PerTaskData_ASM &data)
+                                              PerTaskData_ASM &data) override
     {
       // Aliases for data referenced from the Solid class
       const unsigned int &n_q_points = data.solid->n_q_points;
@@ -1815,7 +1815,7 @@ namespace Cook_Membrane
     virtual void
     assemble_system_tangent_residual_one_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
                                               ScratchData_ASM &scratch,
-                                              PerTaskData_ASM &data)
+                                              PerTaskData_ASM &data) override
     {
       // Aliases for data referenced from the Solid class
       const unsigned int &n_q_points = data.solid->n_q_points;
@@ -1923,7 +1923,7 @@ namespace Cook_Membrane
     virtual void
     assemble_system_tangent_residual_one_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
                                               ScratchData_ASM &scratch,
-                                              PerTaskData_ASM &data)
+                                              PerTaskData_ASM &data) override
     {
       // Aliases for data referenced from the Solid class
       const unsigned int &n_q_points = data.solid->n_q_points;

--- a/goal_oriented_elastoplasticity/elastoplastic.cc
+++ b/goal_oriented_elastoplasticity/elastoplastic.cc
@@ -716,11 +716,11 @@ namespace ElastoPlastic
 
       virtual
       double value (const Point<dim> &p,
-                    const unsigned int component = 0) const;
+                    const unsigned int component = 0) const override;
 
       virtual
       void vector_value (const Point<dim> &p,
-                         Vector<double> &values) const;
+                         Vector<double> &values) const override;
     };
 
     template <int dim>
@@ -782,12 +782,12 @@ namespace ElastoPlastic
       virtual
       void
       vector_value (const Point<dim> &p,
-                    Vector<double>   &values) const;
+                    Vector<double>   &values) const override;
 
       virtual
       void
       vector_value_list (const std::vector<Point<dim> > &points,
-                         std::vector<Vector<double> >   &value_list) const;
+                         std::vector<Vector<double> >   &value_list) const override;
     };
 
 
@@ -868,12 +868,12 @@ namespace ElastoPlastic
       virtual
       void
       vector_value (const Point<dim> &p,
-                    Vector<double>   &values) const;
+                    Vector<double>   &values) const override;
 
       virtual
       void
       vector_value_list (const std::vector<Point<dim> > &points,
-                         std::vector<Vector<double> >   &value_list) const;
+                         std::vector<Vector<double> >   &value_list) const override;
 
     private:
       const double velocity;
@@ -937,12 +937,12 @@ namespace ElastoPlastic
 
       virtual
       void vector_value (const Point<dim> &p,
-                         Vector<double> &values) const;
+                         Vector<double> &values) const override;
 
       virtual
       void
       vector_value_list (const std::vector<Point<dim> > &points,
-                         std::vector<Vector<double> >   &value_list) const;
+                         std::vector<Vector<double> >   &value_list) const override;
     private:
       const double present_time,
                    end_time,
@@ -1026,12 +1026,12 @@ namespace ElastoPlastic
       virtual
       void
       vector_value (const Point<dim> &p,
-                    Vector<double>   &values) const;
+                    Vector<double>   &values) const override;
 
       virtual
       void
       vector_value_list (const std::vector<Point<dim> > &points,
-                         std::vector<Vector<double> >   &value_list) const;
+                         std::vector<Vector<double> >   &value_list) const override;
 
     private:
       const double present_time,
@@ -1120,12 +1120,12 @@ namespace ElastoPlastic
 
         virtual
         void vector_value (const Point<dim> &p,
-                           Vector<double> &values) const;
+                           Vector<double> &values) const override;
 
         virtual
         void
         vector_value_list (const std::vector<Point<dim> > &points,
-                           std::vector<Vector<double> >   &value_list) const;
+                           std::vector<Vector<double> >   &value_list) const override;
       private:
         const double present_time,
                      end_time,
@@ -1206,12 +1206,12 @@ namespace ElastoPlastic
         virtual
         void
         vector_value (const Point<dim> &p,
-                      Vector<double>   &values) const;
+                      Vector<double>   &values) const override;
 
         virtual
         void
         vector_value_list (const std::vector<Point<dim> > &points,
-                           std::vector<Vector<double> >   &value_list) const;
+                           std::vector<Vector<double> >   &value_list) const override;
 
       private:
         const double present_time,
@@ -1273,12 +1273,12 @@ namespace ElastoPlastic
 
       virtual
       void vector_value (const Point<dim> &p,
-                         Vector<double> &values) const;
+                         Vector<double> &values) const override;
 
       virtual
       void
       vector_value_list (const std::vector<Point<dim> > &points,
-                         std::vector<Vector<double> >   &value_list) const;
+                         std::vector<Vector<double> >   &value_list) const override;
     private:
       const double present_time,
                    end_time;
@@ -1345,12 +1345,12 @@ namespace ElastoPlastic
       virtual
       void
       vector_value (const Point<dim> &p,
-                    Vector<double>   &values) const;
+                    Vector<double>   &values) const override;
 
       virtual
       void
       vector_value_list (const std::vector<Point<dim> > &points,
-                         std::vector<Vector<double> >   &value_list) const;
+                         std::vector<Vector<double> >   &value_list) const override;
 
     private:
       const double present_time,
@@ -1426,12 +1426,12 @@ namespace ElastoPlastic
 
       virtual
       void vector_value (const Point<dim> &p,
-                         Vector<double> &values) const;
+                         Vector<double> &values) const override;
 
       virtual
       void
       vector_value_list (const std::vector<Point<dim> > &points,
-                         std::vector<Vector<double> >   &value_list) const;
+                         std::vector<Vector<double> >   &value_list) const override;
 
     private:
       const double present_time,
@@ -1510,12 +1510,12 @@ namespace ElastoPlastic
       virtual
       void
       vector_value (const Point<dim> &p,
-                    Vector<double>   &values) const;
+                    Vector<double>   &values) const override;
 
       virtual
       void
       vector_value_list (const std::vector<Point<dim> > &points,
-                         std::vector<Vector<double> >   &value_list) const;
+                         std::vector<Vector<double> >   &value_list) const override;
 
     private:
       const double present_time,
@@ -1596,7 +1596,7 @@ namespace ElastoPlastic
                     const Vector<double>       &solution,
                     const ConstitutiveLaw<dim> &constitutive_law,
                     const DoFHandler<dim>      &dof_handler_dual,
-                    Vector<double>             &rhs_dual) const;
+                    Vector<double>             &rhs_dual) const override;
 
       DeclException1 (ExcEvaluationPointNotFound,
                       Point<dim>,
@@ -1661,7 +1661,7 @@ namespace ElastoPlastic
                     const Vector<double>       &solution,
                     const ConstitutiveLaw<dim> &constitutive_law,
                     const DoFHandler<dim>      &dof_handler_dual,
-                    Vector<double>             &rhs_dual) const;
+                    Vector<double>             &rhs_dual) const override;
 
       DeclException1 (ExcEvaluationPointNotFound,
                       Point<dim>,
@@ -1755,7 +1755,7 @@ namespace ElastoPlastic
                     const Vector<double>       &solution,
                     const ConstitutiveLaw<dim> &constitutive_law,
                     const DoFHandler<dim>      &dof_handler_dual,
-                    Vector<double>             &rhs_dual) const;
+                    Vector<double>             &rhs_dual) const override;
 
     protected:
       const unsigned int face_id;
@@ -1883,7 +1883,7 @@ namespace ElastoPlastic
                     const Vector<double>       &solution,
                     const ConstitutiveLaw<dim> &constitutive_law,
                     const DoFHandler<dim>      &dof_handler_dual,
-                    Vector<double>             &rhs_dual) const;
+                    Vector<double>             &rhs_dual) const override;
 
     protected:
       const unsigned int face_id;
@@ -2029,7 +2029,7 @@ namespace ElastoPlastic
                     const Vector<double>       &solution,
                     const ConstitutiveLaw<dim> &constitutive_law,
                     const DoFHandler<dim>      &dof_handler_dual,
-                    Vector<double>             &rhs_dual) const;
+                    Vector<double>             &rhs_dual) const override;
 
     protected:
       const std::string base_mesh;

--- a/time_dependent_navier_stokes/time_dependent_navier_stokes.cc
+++ b/time_dependent_navier_stokes/time_dependent_navier_stokes.cc
@@ -320,10 +320,10 @@ namespace fluid
   public:
     BoundaryValues() : Function<dim>(dim + 1) {}
     virtual double value(const Point<dim> &p,
-                         const unsigned int component) const;
+                         const unsigned int component) const override;
 
     virtual void vector_value(const Point<dim> &p,
-                              Vector<double> &values) const;
+                              Vector<double> &values) const override;
   };
 
   template <int dim>

--- a/two_phase_flow/utilities.cc
+++ b/two_phase_flow/utilities.cc
@@ -8,7 +8,7 @@ public:
   InitialPhi (unsigned int PROBLEM, double sharpness=0.005) : Function<dim>(),
     sharpness(sharpness),
     PROBLEM(PROBLEM) {}
-  virtual double value (const Point<dim> &p, const unsigned int component=0) const;
+  virtual double value (const Point<dim> &p, const unsigned int component=0) const override;
   double sharpness;
   unsigned int PROBLEM;
 };
@@ -74,7 +74,7 @@ class BoundaryU : public Function <dim>
 {
 public:
   BoundaryU (unsigned int PROBLEM, double t=0) : Function<dim>(), PROBLEM(PROBLEM) {this->set_time(t);}
-  virtual double value (const Point<dim> &p, const unsigned int component=0) const;
+  virtual double value (const Point<dim> &p, const unsigned int component=0) const override;
   unsigned PROBLEM;
 };
 template <int dim>
@@ -106,7 +106,7 @@ class BoundaryV : public Function <dim>
 {
 public:
   BoundaryV (unsigned int PROBLEM, double t=0) : Function<dim>(), PROBLEM(PROBLEM) {this->set_time(t);}
-  virtual double value (const Point<dim> &p, const unsigned int component=0) const;
+  virtual double value (const Point<dim> &p, const unsigned int component=0) const override;
   unsigned int PROBLEM;
 };
 template <int dim>
@@ -144,7 +144,7 @@ public:
   virtual
   void
   evaluate_scalar_field (const DataPostprocessorInputs::Scalar<dim> &input_data,
-                         std::vector<Vector<double> >               &computed_quantities) const;
+                         std::vector<Vector<double> >               &computed_quantities) const override;
 
   double eps;
   double rho_air;


### PR DESCRIPTION
This was maybe not the most exciting hour I've spent, nor probably the most useful. But we warn these days about virtual functions that are overridden but not marked as `override`. So this fixes the issue throughout the code gallery and makes sure that we can again compile all programs without warnings.