### PR TITLE
Restrict permissions in CI.

### DIFF
--- a/.github/workflows/precice-ci.yml
+++ b/.github/workflows/precice-ci.yml
@@ -8,6 +8,10 @@ on:
   schedule:
   - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   build:
     name: Build ${{ matrix.build_type }}-dealii:${{ matrix.dealii_version }}


### PR DESCRIPTION
Allows to manually trigger a github workflow. Useful in combination with the scheduler, when a critical change in deal.II should be tested immediately.

Also restrict permissions for security reasons.