### PR TITLE
Automatically create issue when scheduled CI is failing.

### DIFF
--- a/.github/action-issue-template.md
+++ b/.github/action-issue-template.md
@@ -1,0 +1,5 @@
+---
+title: "Scheduled GitHub Actions worker is failing"
+---
+
+See [the action log](https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}) for more details.

--- a/.github/workflows/precice-ci.yml
+++ b/.github/workflows/precice-ci.yml
@@ -44,3 +44,13 @@ jobs:
           (./coupled_laplace_problem 2>&1 & ./fancy_boundary_condition >fbc.log)
           sed -i '2d' solution-10.vtk
           numdiff solution-10.vtk test_data/reference-10.vtk
+
+      - name: Create issue about failure
+        if: ${{ failure() && (github.event_name == 'schedule') }}
+        uses: JasonEtco/create-an-issue@v2.9.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/action-issue-template.md
+          update_existing: true
+          search_existing: open


### PR DESCRIPTION
As mentioned in https://github.com/dealii/dealii/issues/15073#issuecomment-1502410198. I followed [this guide](https://epiforecasts.io/posts/2022-04-11-robust-actions/#notify-the-whole-team-when-a-scheduled-workflow-fails) essentially.