### PR TITLE
CI now covers compilation of all projects.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,4 +1,4 @@
-name: PreCICE CI
+name: github-linux
 
 on:
   push:
@@ -29,21 +29,44 @@ jobs:
       options: --user root
 
     steps:
+      - name: Install dependencies from repository
+        run: |
+          apt-get -y update
+          apt-get -y install libarmadillo-dev libconfig++-dev
+
       - name: Install preCICE
         run: |
-          sudo apt-get -y update
-          wget https://github.com/precice/precice/releases/download/v2.5.0/libprecice2_2.5.0_${{ matrix.ubuntu_version }}.deb
-          sudo apt-get -y install ./libprecice2_2.5.0_${{ matrix.ubuntu_version }}.deb
+          wget -O libprecice.deb https://github.com/precice/precice/releases/download/v2.5.0/libprecice2_2.5.0_${{ matrix.ubuntu_version }}.deb
+          apt-get -y install ./libprecice.deb
+
+      - name: Install XBraid
+        run: |
+          wget -O xbraid.tar.gz https://github.com/XBraid/xbraid/archive/refs/tags/v3.1.0.tar.gz
+          mkdir /opt/xbraid
+          tar xf xbraid.tar.gz -C /opt/xbraid --strip-components 1
+          cd /opt/xbraid/braid
+          make
+          echo "BRAID_DIR=${PWD}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v3
 
-      - name: Compile
+      - name: Compile all projects
         run: |
-          cd coupled_laplace_problem
-          cmake .
-          make
+          for dir in */
+          do
+            cd ${dir}
+            if [ -e CMakeLists.txt ]
+            then
+              echo "Current project: ${dir}"
+              cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} .
+              make
+            else
+              echo "Skipping project: ${dir}"
+            fi
+            cd ..
+          done
 
-      - name: Test
+      - name: Test coupled_laplace_problem
         run: |
           cd coupled_laplace_problem
           (./coupled_laplace_problem 2>&1 & ./fancy_boundary_condition >fbc.log)

--- a/CeresFE/src/ceres.cc
+++ b/CeresFE/src/ceres.cc
@@ -426,9 +426,7 @@ namespace Step22
 
     constraints.close();
 
-    std::vector<types::global_dof_index> dofs_per_block(2);
-    DoFTools::count_dofs_per_block(dof_handler, dofs_per_block,
-                                   block_component);
+    std::vector<types::global_dof_index> dofs_per_block = DoFTools::count_dofs_per_fe_block(dof_handler, block_component);
     n_u = dofs_per_block[0];
     n_p = dofs_per_block[1];
 

--- a/CeresFE/src/ceres.cc
+++ b/CeresFE/src/ceres.cc
@@ -214,9 +214,9 @@ namespace Step22
     }
 
     virtual double value(const Point<dim> &p,
-                         const unsigned int component = 0) const;
+                         const unsigned int component = 0) const override;
 
-    virtual void vector_value(const Point<dim> &p, Vector<double> &value) const;
+    virtual void vector_value(const Point<dim> &p, Vector<double> &value) const override;
   };
 
   template<int dim>

--- a/parallel_in_time/CMakeLists.txt
+++ b/parallel_in_time/CMakeLists.txt
@@ -48,24 +48,16 @@ IF(NOT ${deal.II_FOUND})
 ENDIF()
 
 # Find braid details
-IF(NOT "$ENV{BRAID_DIR}" STREQUAL "")
-    SET(BRAID_DIR "$ENV{BRAID_DIR}" CACHE INTERNAL "Copied BRAID_DIR from environment variable")
-ENDIF()
-
-IF("${CMAKE_FIND_LIBRARY_PREFIXES}" STREQUAL "")
-    SET(CMAKE_FIND_LIBRARY_PREFIXES "lib")
-ENDIF()
+SET(BRAID_DIR "$ENV{BRAID_DIR}" CACHE INTERNAL "Copied BRAID_DIR from environment variable")
 
 FIND_PATH(BRAID_INCLUDE_DIR
   NAMES braid.h
   HINTS ${BRAID_DIR}
-  PATH_SUFFIXES include
   )
 
 FIND_LIBRARY(BRAID_LIBRARY
-  NAMES braid.a
+  NAMES libbraid.a
   HINTS ${BRAID_DIR}
-  PATH_SUFFIXES lib64 lib
   )
 
 MESSAGE(STATUS "Braid include directory: ${BRAID_INCLUDE_DIR}")


### PR DESCRIPTION
Part of https://github.com/dealii/dealii/issues/15073.

I believe this is the most convenient and low-maintenance way to verify that all code-gallery programs compile.

`CeresFE` couldn't be compiled with deal.II 9.4 because of a deprecated function that has been deleted. I've updated it in this patch so that the CI will pass.

`parallel_in_time` finds the braid include folder, but has issues finding the actual library. I've changed a few lines in its `CMakeLists.txt`.