### PR TITLE
Limit report of CI failures to main repository.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,7 +74,7 @@ jobs:
           numdiff solution-10.vtk test_data/reference-10.vtk
 
       - name: Create issue about failure
-        if: ${{ failure() && (github.event_name == 'schedule') }}
+        if: ${{ failure() && (github.event_name == 'schedule') && (github.repository_owner == 'dealii') }}
         uses: JasonEtco/create-an-issue@v2.9.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Current CI settings also triggers a report on all forks, see https://github.com/marcfehling/code-gallery/issues/5. It is enough to have them in the main organization repository.