### PR TITLE
github-actions: Only run scheduled jobs on main repository, and no longer on forks.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ master ]
   schedule:
-  - cron: '0 0 * * 0'
+  - cron: '0 0 * * SUN'
 
 permissions:
   contents: read
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   build:
+    if: (github.event_name == 'schedule' && github.repository == 'dealii/code-gallery') || github.event_name != 'schedule'
+
     name: Build ${{ matrix.build_type }}-dealii:${{ matrix.dealii_version }}-${{ matrix.ubuntu_version }}
     runs-on: ubuntu-latest
 
@@ -74,7 +76,7 @@ jobs:
           numdiff solution-10.vtk test_data/reference-10.vtk
 
       - name: Create issue about failure
-        if: ${{ failure() && (github.event_name == 'schedule') && (github.repository_owner == 'dealii') }}
+        if: failure() && github.event_name == 'schedule'
         uses: JasonEtco/create-an-issue@v2.9.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Learned something new in https://github.com/dealii/dealii/pull/16063/, so I thought it might also be helpful here.