### PR TITLE
github-actions: make workflow more robust.

### DIFF
--- a/.github/action-issue-template.md
+++ b/.github/action-issue-template.md
@@ -2,4 +2,6 @@
 title: "Scheduled GitHub Actions worker is failing"
 ---
 
+The following projects failed to either configure, build or test: {{ env.error_compile }} {{ env.error_test }}
+
 See [the action log](https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}) for more details.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,26 +54,27 @@ jobs:
 
       - name: Compile all projects
         run: |
-          for dir in */
-          do
+          for dir in */; do
             cd ${dir}
-            if [ -e CMakeLists.txt ]
-            then
+            if [ -e CMakeLists.txt ]; then
               echo "Current project: ${dir}"
-              cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} .
-              make
+              (cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} . && make) || err="${err} ${dir}"
             else
               echo "Skipping project: ${dir}"
             fi
             cd ..
           done
+          if [ -n "${err}" ]; then
+            echo "error_compile=${err}" >> $GITHUB_ENV
+            exit 1
+          fi
 
       - name: Test coupled_laplace_problem
         run: |
           cd coupled_laplace_problem
           (./coupled_laplace_problem 2>&1 & ./fancy_boundary_condition >fbc.log)
           sed -i '2d' solution-10.vtk
-          numdiff solution-10.vtk test_data/reference-10.vtk
+          numdiff solution-10.vtk test_data/reference-10.vtk || (echo "error_test=coupled_laplace_problem/" >> $GITHUB_ENV && exit 1)
 
       - name: Create issue about failure
         if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
The current workflow exits upon the first error, shadowing potential failures in other projects.

With this PR, we mark projects that won't build, compile, or test. A stage fails when any project has been marked.

The list of failing projects will be forwarded to the issue template. An exemplary issue looks like [this](https://github.com/marcfehling/code-gallery/issues/9).