### PR TITLE
Update actions/checkout to v4.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,7 +50,7 @@ jobs:
           make
           echo "BRAID_DIR=${PWD}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Compile all projects
         run: |


### PR DESCRIPTION
We get warnings of the kind:

`Please update the following actions to use Node.js 20: actions/checkout@v3`