### PR TITLE
Fix the style in which the email address of an author is given.

### DIFF
--- a/nonlinear-heat_transfer_with_AD_NOX/doc/author
+++ b/nonlinear-heat_transfer_with_AD_NOX/doc/author
@@ -1,1 +1,1 @@
-Narasimhan Swaminathan (n.swaminathan@iitm.ac.in)
+Narasimhan Swaminathan <n.swaminathan@iitm.ac.in>


### PR DESCRIPTION
Currently, this shows up as double parentheses at https://dealii.org/developer/doxygen/deal.II/CodeGallery.html .