### PR TITLE
Fix tutorials with SolutionTransfer.

### DIFF
--- a/ElastoplasticTorsion/ElastoplasticTorsion.cc
+++ b/ElastoplasticTorsion/ElastoplasticTorsion.cc
@@ -273,8 +273,8 @@ namespace nsp
   ComputeMultiplier<dim>::get_names() const
   {
     std::vector<std::string> solution_names;
-    solution_names.push_back ("Gradient norm");
-    solution_names.push_back ("Lagrange multiplier");
+    solution_names.push_back ("Gradient_norm");
+    solution_names.push_back ("Lagrange_multiplier");
     return solution_names;
   }
 
@@ -779,6 +779,7 @@ namespace nsp
     triangulation.execute_coarsening_and_refinement();
     dof_handler.distribute_dofs(fe);
 #  if DEAL_II_VERSION_GTE(9, 7, 0)
+    present_solution.reinit(dof_handler.n_dofs());
     solution_transfer.interpolate(present_solution);
 #  else
     Vector<double> tmp(dof_handler.n_dofs());

--- a/TravelingWaves/TravelingWaveSolver.cc
+++ b/TravelingWaves/TravelingWaveSolver.cc
@@ -292,7 +292,7 @@ namespace TravelingWave
           );
         };
 
-        auto kappa_2 = [=](double T, double lambda){
+        auto kappa_2 = [=](double T, double /*lambda*/){
           return -problem.k * std::exp(-problem.theta / T) * Heaviside_func(T - problem.T_ign);
         };
 
@@ -637,6 +637,7 @@ namespace TravelingWave
     setup_system(/*initial_step=*/ false);
 
 #  if DEAL_II_VERSION_GTE(9, 7, 0)
+    current_solution.reinit(dof_handler.n_dofs());
     solution_transfer.interpolate(current_solution);
 #  else
     Vector<double> tmp(dof_handler.n_dofs());

--- a/goal_oriented_elastoplasticity/elastoplastic.cc
+++ b/goal_oriented_elastoplasticity/elastoplastic.cc
@@ -5608,6 +5608,12 @@ namespace ElastoPlastic
 
 #  if DEAL_II_VERSION_GTE(9, 7, 0)
     // stress
+    for (unsigned int i=0; i<dim; ++i)
+      for (unsigned int j=0; j<dim; ++j)
+        {
+          history_stress_field[i][j].reinit(history_dof_handler.n_dofs());
+        }
+
     history_stress_field_transfer0.interpolate(history_stress_field[0]);
     if ( dim > 1)
       {
@@ -5619,6 +5625,12 @@ namespace ElastoPlastic
       }
 
     // strain
+    for (unsigned int i=0; i<dim; ++i)
+      for (unsigned int j=0; j<dim; ++j)
+        {
+          history_strain_field[i][j].reinit(history_dof_handler.n_dofs());
+        }
+
     history_strain_field_transfer0.interpolate(history_strain_field[0]);
     if ( dim > 1)
       {


### PR DESCRIPTION
Vectors needs to be properly initialized. This also needs to be updated in the deal.II documentation.

I get errors of the kind
```
An error occurred in line <252> of file </dealii/source/numerics/solution_transfer.cc> in function
    void dealii::SolutionTransfer<dim, VectorType, spacedim>::interpolate(std::vector<VectorType*>&) [with int dim = 1; VectorType = dealii::Vector<double>; int spacedim = 1]
The violated condition was: 
    all_out[i]->size() == dof_handler->n_dofs()
Additional information: 
    Two sizes or dimensions were supposed to be equal, but aren't. They
    are 423 and 366.
```

---

I tried to fix some other things on the way to make the programs run as well. Lots of changes to the `DataOut` interface caused lots of errors in the code-gallery programs at runtime. For examples, I couldn't get `ElastoplasticTorsion` to run since it lacks an overridden version of `DataPostprocessor::evaluate_scalar_field`.

EDIT: I now saw that this particular issue is already tracked in #129.