### PR TITLE
Address a number of doxygen issues.

### DIFF
--- a/advection_reaction_estimator/source/DG_advection_reaction.cc
+++ b/advection_reaction_estimator/source/DG_advection_reaction.cc
@@ -852,8 +852,8 @@ AdvectionReaction<dim>::compute_local_projection_and_estimate()
       }
   };
 
-  // Here, we finally handle the assembly of the Mass matrix (M)_{ij} = (\phi_j,
-  // \phi_i)_T. We pass in ScratchData and CopyData objects
+  // Here, we finally handle the assembly of the Mass matrix $(M)_{ij} = (\phi_j,
+  // \phi_i)_T$. We pass in ScratchData and CopyData objects
   CopyData copy_data;
   MeshWorker::mesh_loop(dof_handler.begin_active(),
                         dof_handler.end(),

--- a/coupled_laplace_problem/README.md
+++ b/coupled_laplace_problem/README.md
@@ -15,7 +15,7 @@ Coupled simulations deal mostly with time-dependent problems. Hence, we make the
   \\
   u &= g(t) \qquad\qquad & \text{on}\ \partial\Omega_c.
 @f}
-with the fixed Dirichlet boundary \Omega_s, the coupling boundary \Omega_c and the time-dependent coupling data g(t).
+with the fixed Dirichlet boundary $\Omega_s$, the coupling boundary $\Omega_c$ and the time-dependent coupling data $g(t)$.
 
 The system is consequently discretized by a first-order backward Euler method, resulting in
 @f{align*}

--- a/parallel_in_time/Readme.md
+++ b/parallel_in_time/Readme.md
@@ -138,7 +138,7 @@ This is expected behavior as second order finite elements are used.
 Code Organization
 -----------------
 
-#### The src directory
+### The src directory
 
 The entry point of the code is in parallel\_in\_time.cc and sets up XBraid for a simulation.
 The XBraid setup involves initializing the app struct and configuring XBraid for the desired number of timesteps, number of iterations, and so forth.
@@ -147,12 +147,12 @@ The HeatEquation class and all deal.II functionality is declared in `HeatEquatio
 Since HeatEquation is a class template, its definition file `HeatEquationImplem.hh` is included at the bottom of `HeatEquation.hh`.
 Lastly various helper functions and variables such as the current processor id and the output stream are declared in `Utilities.hh` and defined in `Utilities.cc`.
 
-#### The test directory
+### The test directory
 
 This directory contains tests to be built and run with CMake.
 These tests verify the correct implementation of the various functions.
 
-#### The doc directory
+### The doc directory
 
 This directory is for storing further documentation of the code.
 Not much is in this directory right now as most of the documentation is in the Readme or in comments of the source code files.


### PR DESCRIPTION
These show up as warnings in doxygen.log that are relatively easy to fix.