### PR TITLE
Initialize DynamicSparsityPattern correctly.

### DIFF
--- a/Distributed_LDG_Method/LDGPoisson.cc
+++ b/Distributed_LDG_Method/LDGPoisson.cc
@@ -364,7 +364,7 @@ make_dofs()
   // pattern we use the DoFTools::make_flux_sparsity_pattern function
   // since we using a DG method and need to take into account the DG
   // fluxes in the sparsity pattern.
-  DynamicSparsityPattern dsp(dof_handler.n_dofs());
+  DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_flux_sparsity_pattern(dof_handler,
                                        dsp);
 

--- a/cdr/solver/cdr.cc
+++ b/cdr/solver/cdr.cc
@@ -195,7 +195,7 @@ template <int dim>
 void
 CDRProblem<dim>::setup_system()
 {
-  DynamicSparsityPattern dynamic_sparsity_pattern(dof_handler.n_dofs());
+  DynamicSparsityPattern dynamic_sparsity_pattern(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(dof_handler,
                                   dynamic_sparsity_pattern,
                                   constraints,


### PR DESCRIPTION
Part of #219.

Fixes `cdr` and partly fixes `Distributed_LDG_Method`.