### PR TITLE
Fix `PMPI_Abort` in `two_phase_flow/MultiPhase`.

### DIFF
--- a/two_phase_flow/NavierStokesSolver.cc
+++ b/two_phase_flow/NavierStokesSolver.cc
@@ -867,6 +867,7 @@ void NavierStokesSolver<dim>::assemble_system_U()
         }
     }
   rebuild_Matrix_U=true;
+  rebuild_Matrix_U_preconditioners=true;
 }
 
 template<int dim>


### PR DESCRIPTION
Fixes #224. Related to #219.

Always rebuilding velocity preconditioners fixes the `BoomerAMG` issue.

However, I believe that this fix only masks the actual problem, and does not solve it. For instance, the program `TestNavierStokes` works fine.

I am fine with this solution though, as I have other problems to work on and already spent a significant amount of time on this. Do you agree with this patch? 

@manuel-quezada -- FYI