### PR TITLE
Keep GitHub actions alive

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -89,3 +89,11 @@ jobs:
           filename: .github/action-issue-template.md
           update_existing: true
           search_existing: open
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
The Actions didn't run on recent pull requests since GitHub disables them after 60 days of inactivity.