### PR TITLE
Do not report failure if project cannot be configured.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,16 +58,23 @@ jobs:
 
       - name: Compile all projects
         run: |
+          log="\nSummary:"
           for dir in */; do
             cd ${dir}
-            if [ -e CMakeLists.txt ]; then
-              echo "Current project: ${dir}"
-              (cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} . && make) || err="${err} ${dir}"
+            log="${log}\n  $(printf '%-70s' "${dir}")"
+            if cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} . ; then
+              if make ; then
+                log="${log} passed."
+              else
+                log="${log} FAILED."
+                err="${err} ${dir}"
+              fi
             else
-              echo "Skipping project: ${dir}"
+              log="${log} skipped."
             fi
             cd ..
           done
+          echo -e "${log}"
           if [ -n "${err}" ]; then
             echo "error_compile=${err}" >> $GITHUB_ENV
             exit 1


### PR DESCRIPTION
Our CI script strictly reports failure if a project cannot be configured. This patch relaxes this requirement by skipping projects that cannot be configured by cmake, e.g., because they miss dependencies or require a more recent version of deal.II.

This is motivated by the fact that #240 requires PETSc to be configured with complex support, which our docker image does not provide. Further, new contributions often require the latest deal.II installation, which causes failures in the CI because we also check on older deal.II versions. This requires contributors to make the code backwards-compatible and adds extra work for them just to make the CI pass -- I do not see any necessity for it and would rather relax the requirements.

This patch also adds a short summary at the end. This is the output on my machine. I do not have preCISE nor XBraid installed, thus I could not configure `coupled_laplace_problem` and `parallel_in_time`. `Magneto_Active_Polymers_Book` will always be skipped because the folder does not contain a `CMakeLists.txt`.
```
Summary:
  advection_reaction_estimator                                           passed.
  cdr                                                                    passed.
  CeresFE                                                                passed.
  coupled_laplace_problem                                                skipped.
  Crystal_Growth_Phase_Field_Model                                       passed.
  Distributed_LDG_Method                                                 passed.
  Distributed_Moving_Laser_Heating                                       passed.
  ElastoplasticTorsion                                                   passed.
  goal_oriented_elastoplasticity                                         passed.
  Heat_Eqn_Parallel                                                      passed.
  information_based_mesh_refinement                                      passed.
  Linear_Elastic_Active_Skeletal_Muscle_Model                            passed.
  Magneto_Active_Polymers_Book                                           skipped.
  Maxwell-Eigenvalue-hp-Refinement                                       passed.
  MCMC-Laplace                                                           passed.
  MultipointFluxMixedFiniteElementMethods                                passed.
  NavierStokes_TRBDF2_DG                                                 passed.
  nonlinear-heat_transfer_with_AD_NOX                                    passed.
  Nonlinear_PoroViscoelasticity                                          passed.
  parallel_in_time                                                       skipped.
  Phase_field_fracture_model_in_3D                                       passed.
  Quasi_static_Finite_strain_Compressible_Elasticity                     passed.
  Quasi_static_Finite_strain_Quasi_incompressible_ViscoElasticity        passed.
  Swift-Hohenberg-Solver                                                 passed.
  time_dependent_navier_stokes                                           passed.
  TravelingWaves                                                         passed.
  two_phase_flow                                                         passed.
```