### PR TITLE
Add a necessary header include file.

### DIFF
--- a/agglomeration_poisson/source/agglomeration_handler.cc
+++ b/agglomeration_poisson/source/agglomeration_handler.cc
@@ -9,6 +9,7 @@
  * -----------------------------------------------------------------------------
  */
 
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/lac/sparsity_tools.h>
 
 #include <agglomeration_handler.h>


### PR DESCRIPTION
Our periodic code-gallery checker complains about an undeclared class: https://github.com/dealii/code-gallery/actions/runs/27483779690/job/81236057126
Fix this by adding the necessary header include.