### PR TITLE
ALE_Finite_Strain_Plasticity: fix deal.II 9.7 assertion, build cleanly, and run under MPI

### DIFF
--- a/ALE_Finite_Strain_Plasticity/src/BoundaryUnidirectionalPenaltySpec.h
+++ b/ALE_Finite_Strain_Plasticity/src/BoundaryUnidirectionalPenaltySpec.h
@@ -30,9 +30,9 @@ namespace PlasticityLab {
 
   private:
     const unsigned int boundary_id;
-    const Number quadratic_spring_factor;
     const Number reference_displacement_increment;
     const Number residual_force;
+    const Number quadratic_spring_factor;
   };
 
 } /* namespace PlasticityLab */

--- a/ALE_Finite_Strain_Plasticity/src/DoFSystem.h
+++ b/ALE_Finite_Strain_Plasticity/src/DoFSystem.h
@@ -50,10 +50,9 @@ namespace PlasticityLab {
   void DoFSystem<dim, Number>::setup_dof_system (const FiniteElement<dim> &fe) {
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    locally_relevant_dofs.clear();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
 
-    nodal_constraints.reinit(locally_relevant_dofs);
+    nodal_constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints (dof_handler, nodal_constraints);
   }
 

--- a/ALE_Finite_Strain_Plasticity/src/ExponentialHardeningElastoplasticMaterial.cpp
+++ b/ALE_Finite_Strain_Plasticity/src/ExponentialHardeningElastoplasticMaterial.cpp
@@ -49,17 +49,17 @@ namespace PlasticityLab {
 
   template <int dim, typename Number>
   std::vector<Number> ExponentialHardeningElastoplasticMaterial<dim, Number>::get_state_parameters(
-      const point_index_t &point_index,
-      const Tensor<2, dim, Number> &reference_transformation) const {
+      const point_index_t &,
+      const Tensor<2, dim, Number> &) const {
     throw NotImplementedException();
   }
 
   template <int dim, typename Number>
   void ExponentialHardeningElastoplasticMaterial<dim, Number>::
   set_state_parameters(
-        const point_index_t &point_index,
-        const std::vector<Number> &state_parameters,
-        const Tensor<2, dim, Number> &reference_transformation) {
+        const point_index_t &,
+        const std::vector<Number> &,
+        const Tensor<2, dim, Number> &) {
     throw NotImplementedException();
   }
 
@@ -71,12 +71,12 @@ namespace PlasticityLab {
 
 
   template <int dim, typename Number>
-  Number ExponentialHardeningElastoplasticMaterial<dim, Number>::get_material_Jacobian(const point_index_t &point_index) const {
+  Number ExponentialHardeningElastoplasticMaterial<dim, Number>::get_material_Jacobian(const point_index_t &) const {
     throw NotImplementedException();
   }
 
   template <int dim, typename Number>
-  dealii::SymmetricTensor<2, dim, Number> ExponentialHardeningElastoplasticMaterial<dim, Number>::get_plastic_strain(const point_index_t &point_index) const {
+  dealii::SymmetricTensor<2, dim, Number> ExponentialHardeningElastoplasticMaterial<dim, Number>::get_plastic_strain(const point_index_t &) const {
     throw NotImplementedException();
   }
 

--- a/ALE_Finite_Strain_Plasticity/src/ExponentialHardeningElastoplasticMaterial.h
+++ b/ALE_Finite_Strain_Plasticity/src/ExponentialHardeningElastoplasticMaterial.h
@@ -31,22 +31,22 @@ namespace PlasticityLab {
 
     void compute_constitutive_request(
       ConstitutiveModelRequest<dim, Number> &constitutive_request,
-      const point_index_t &point_index);
+      const point_index_t &point_index) override;
 
-    Number get_material_Jacobian(const point_index_t &point_index) const;
-    dealii::SymmetricTensor<2, dim, Number> get_plastic_strain(const point_index_t &point_index) const;
+    Number get_material_Jacobian(const point_index_t &point_index) const override;
+    dealii::SymmetricTensor<2, dim, Number> get_plastic_strain(const point_index_t &point_index) const override;
 
-    void setup_point_history (const point_index_t point_count);
+    void setup_point_history (const point_index_t point_count) override;
 
     std::vector<Number> get_state_parameters(
               const point_index_t &point_index,
-              const Tensor<2, dim, Number> &reference_transformation=unit_symmetric_tensor<dim>()) const;
+              const Tensor<2, dim, Number> &reference_transformation=unit_symmetric_tensor<dim>()) const override;
 
     void  set_state_parameters(
               const point_index_t &point_index,
               const std::vector<Number> &state_parameters,
-              const Tensor<2, dim, Number> &reference_transformation);
-    size_t get_material_parameter_count() const;
+              const Tensor<2, dim, Number> &reference_transformation) override;
+    size_t get_material_parameter_count() const override;
 
    private:
     const Number kappa;

--- a/ALE_Finite_Strain_Plasticity/src/ExponentialHardeningThermoviscoplasticYieldLaw.h
+++ b/ALE_Finite_Strain_Plasticity/src/ExponentialHardeningThermoviscoplasticYieldLaw.h
@@ -52,7 +52,7 @@ namespace PlasticityLab {
   Number hardening_alpha_derivatives(Number &D_isotropic_hardening,
                                           Number &D_kinematic_hardening,
                                           const Number alpha,
-                                          const Number gamma,
+                                          [[maybe_unused]] const Number gamma,
                                           const Number time_increment,
                                           const Number temperature) const {
     Number Dh = (delta * (K_infty - K_0) * exp(-delta * alpha) + H_bar) * (1 - std::min(softening_threshold, hardening_softening * (temperature - reference_temperature)))
@@ -65,8 +65,8 @@ namespace PlasticityLab {
   Number hardening_temperature_derivatives(Number &D_isotropic_hardening,
                                                 Number &D_kinematic_hardening,
                                                 const Number alpha,
-                                                const Number gamma,
-                                                const Number time_increment,
+                                                [[maybe_unused]] const Number gamma,
+                                                [[maybe_unused]] const Number time_increment,
                                                 const Number temperature) const {
     Number Dh = (hardening_softening * (temperature - reference_temperature) < softening_threshold)?
                 -flow_stress_softening * K_0

--- a/ALE_Finite_Strain_Plasticity/src/JohnsonCookThermoviscoplasticYieldLaw.h
+++ b/ALE_Finite_Strain_Plasticity/src/JohnsonCookThermoviscoplasticYieldLaw.h
@@ -129,7 +129,7 @@ namespace PlasticityLab {
       const Number minimum_strain_rate = creep_strain_rate_factor * epsilon_dot_0;
       const Number strain_rate = std::max(sqrt2thirds*gamma/time_increment, minimum_strain_rate);
       const Number softened_quasistatic_elastoplastic_stress = get_elastoplastic_factor(alpha) * get_softening_factor(temperature);
-      const Number Carreau_viscocity = get_Carreau_viscocity(strain_rate, softened_quasistatic_elastoplastic_stress);
+      [[maybe_unused]] const Number Carreau_viscocity = get_Carreau_viscocity(strain_rate, softened_quasistatic_elastoplastic_stress);
       const Number stress_temperature_tangent =
               get_elastoplastic_factor(alpha) * get_softening_factor_tangent(temperature);
       Number Carreau_viscocity_strain_rate_tangent, Carreau_viscocity_stress_tangent;

--- a/ALE_Finite_Strain_Plasticity/src/PlasticityLabProg.cpp
+++ b/ALE_Finite_Strain_Plasticity/src/PlasticityLabProg.cpp
@@ -36,7 +36,7 @@ namespace PlasticityLab {
     pcout(std::cout,
           (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)),
     order(1),
-    mech_fe(FE_Q<dim>(order), dim, FE_Q<dim>(order), 2),
+    mech_fe(FE_Q<dim>(order), dim, FE_Q<dim>(order), 1),
     therm_fe(order),
     mixed_var_fe(order-1),
     mesh_motion_fe(FE_Q<dim>(order), dim),
@@ -205,7 +205,7 @@ namespace PlasticityLab {
       std::unordered_map<point_index_t, Tensor<2, dim+1, Number>> &remapped_deformation_gradients) {
 
     const unsigned int n_q_points = quadrature_formula.size();
-    const unsigned int dofs_per_cell = mesh_motion_fe.dofs_per_cell;
+    [[maybe_unused]] const unsigned int dofs_per_cell = mesh_motion_fe.dofs_per_cell;
     const unsigned int mixed_dofs_per_cell = mixed_fe_dof_system.dof_handler.get_fe().dofs_per_cell;
 
     FEValues<dim> mesh_motion_fe_values(
@@ -253,7 +253,7 @@ namespace PlasticityLab {
           mesh_motion_value_increments);
 
         for (unsigned int q_point = 0; q_point < n_q_points; ++q_point) {
-          const point_index_t quadrature_point_index = cell->user_index() + q_point;
+          [[maybe_unused]] const point_index_t quadrature_point_index = cell->user_index() + q_point;
           const Point<dim, Number> reference_point_position = mesh_motion_fe_values.quadrature_point(q_point);
           const Point<dim, Number> remapped_point_position = reference_point_position - mesh_motion_value_increments[q_point];
 
@@ -506,7 +506,7 @@ namespace PlasticityLab {
         for(unsigned int q_point=0; q_point<n_q_points; q_point++) {
           const point_index_t quadrature_point_index = remapped_point.mesh_motion_cell->user_index() + q_point;
 
-          const auto deformation_gradient =
+          [[maybe_unused]] const auto deformation_gradient =
             get_deformation_gradient(
               previous_deformation_gradients[q_point],
               previous_deformation_values[q_point][0]/mesh_motion_fe_values.quadrature_point(q_point)[0]);
@@ -648,7 +648,7 @@ namespace PlasticityLab {
           mesh_motion_nonlinear_system.current_increment,
           mesh_motion_value_increments);
 
-        const auto mesh_motion_gradient = get_deformation_gradient(
+        [[maybe_unused]] const auto mesh_motion_gradient = get_deformation_gradient(
                                             -mesh_motion_gradient_increments[reference_point.q_point],
                                             -mesh_motion_value_increments[reference_point.q_point][0]/mesh_motion_fe_values.quadrature_point(reference_point.q_point)[0]);
 
@@ -672,7 +672,7 @@ namespace PlasticityLab {
     const Quadrature<dim> thermal_fe_support_point_quadrature(therm_fe.get_unit_support_points());
 
     const unsigned int n_q_points = thermal_fe_support_point_quadrature.size();
-    const unsigned int dofs_per_cell = mesh_motion_fe.dofs_per_cell;
+    [[maybe_unused]] const unsigned int dofs_per_cell = mesh_motion_fe.dofs_per_cell;
     const unsigned int thermal_dofs_per_cell = therm_fe.dofs_per_cell;
 
     FEValues<dim> mesh_motion_fe_values(
@@ -1045,7 +1045,7 @@ namespace PlasticityLab {
     const Quadrature<dim> mechanical_fe_support_point_quadrature(mech_fe.base_element(0).get_unit_support_points());
 
     const unsigned int n_q_points = mechanical_fe_support_point_quadrature.size();
-    const unsigned int dofs_per_cell = mesh_motion_fe.dofs_per_cell;
+    [[maybe_unused]] const unsigned int dofs_per_cell = mesh_motion_fe.dofs_per_cell;
     const unsigned int mechanical_dofs_per_cell = mech_fe.dofs_per_cell;
 
     FEValues<dim> mesh_motion_fe_values(
@@ -1772,7 +1772,7 @@ namespace PlasticityLab {
             );
           const Number material_Jacobian = material.get_material_Jacobian(quadrature_point_index) / determinant(current_F);
 
-          const auto mesh_motion_gradient = get_deformation_gradient(
+          [[maybe_unused]] const auto mesh_motion_gradient = get_deformation_gradient(
             -mesh_motion_gradient_increments[q_point],
             -mesh_motion_value_increments[q_point][0]/fe_values.quadrature_point(q_point)[0]);
 
@@ -1877,7 +1877,7 @@ namespace PlasticityLab {
             (current_displacement_values[q_point][0] + displacement_value_increments[q_point][0])/radius);
 
           const Number material_Jacobian = material.get_material_Jacobian(quadrature_point_index) / determinant(current_F);
-          const Number mesh_motion_Jacobian = determinant(mesh_motion_gradient);
+          [[maybe_unused]] const Number mesh_motion_Jacobian = determinant(mesh_motion_gradient);
 
           const auto inv_updated_F = invert(updated_F);
           const Number Jacobian = determinant(updated_F) * material_Jacobian;
@@ -1986,23 +1986,23 @@ namespace PlasticityLab {
             * (-(1.0/radius) * one_plus_r_over_R_n * 2 * d_thR_d_t_n * d_time_rate_d_increment);
 
 
-          const auto d2_x_dt_2_n_plus_1_minus_alpha_m =
+          [[maybe_unused]] const auto d2_x_dt_2_n_plus_1_minus_alpha_m =
             alpha_m * displacement_previous_second_time_rate + (1-alpha_m)*d2_x_dt_2_n_plus_1;
-          const Number d2_x_dt_2_tangent_1_minus_alpha_m = (1-alpha_m)*d_second_time_rate_d_increment;
+          [[maybe_unused]] const Number d2_x_dt_2_tangent_1_minus_alpha_m = (1-alpha_m)*d_second_time_rate_d_increment;
 
-          const auto d_Fc_dt_vc_n_plus_1_minus_alpha_f =
+          [[maybe_unused]] const auto d_Fc_dt_vc_n_plus_1_minus_alpha_f =
                         alpha_m * displacement_gradient_previous_time_rate * vc_n
                         + (1-alpha_m) * Grad_d_x_d_t_n_plus_1 * vc_n_plus_1;
 
-          const auto d_Fc_dt_vc_n_plus_1_minus_alpha_f_F_tangent = (1-alpha_m) * d_time_rate_d_increment * vc_n_plus_1;
-          const auto d_Fc_dt_vc_n_plus_1_minus_alpha_f_v_tangent = (1-alpha_m) * Grad_d_x_d_t_n_plus_1;
+          [[maybe_unused]] const auto d_Fc_dt_vc_n_plus_1_minus_alpha_f_F_tangent = (1-alpha_m) * d_time_rate_d_increment * vc_n_plus_1;
+          [[maybe_unused]] const auto d_Fc_dt_vc_n_plus_1_minus_alpha_f_v_tangent = (1-alpha_m) * Grad_d_x_d_t_n_plus_1;
 
-          const auto F_c_d_vc_d_t_n_plus_1_minus_alpha_m =
+          [[maybe_unused]] const auto F_c_d_vc_d_t_n_plus_1_minus_alpha_m =
             alpha_m * current_F * d_vc_d_t_n
             + (1-alpha_m) * updated_F * d_vc_d_t_n_plus_1;
 
-          const auto F_c_d_vc_d_t_n_plus_1_minus_alpha_m_F_tangent = (1-alpha_m) * d_vc_d_t_n_plus_1;
-          const auto F_c_d_vc_d_t_n_plus_1_minus_alpha_m_V_tangent = (1-alpha_m) * updated_F * d_second_time_rate_d_increment;
+          [[maybe_unused]] const auto F_c_d_vc_d_t_n_plus_1_minus_alpha_m_F_tangent = (1-alpha_m) * d_vc_d_t_n_plus_1;
+          [[maybe_unused]] const auto F_c_d_vc_d_t_n_plus_1_minus_alpha_m_V_tangent = (1-alpha_m) * updated_F * d_second_time_rate_d_increment;
 
           std::vector<Tensor<2, dim+1, Number>> rate_gradients(dofs_per_cell);
           std::vector<Tensor<2, dim+1, Number>> angular_rate_gradients(dofs_per_cell);
@@ -2249,7 +2249,7 @@ namespace PlasticityLab {
 
         for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face) {
           for (auto boundaryForceSpec: mechanical_lbc_system.boundaryLoadAppliers) {
-            if (cell->face(face)->boundary_id() == boundaryForceSpec.first) {
+            if (cell->face(face)->boundary_id() == static_cast<types::boundary_id>(boundaryForceSpec.first)) {
               fe_face_values.reinit(cell, face);
               for (unsigned int q_point = 0; q_point < n_face_q_points; ++q_point) {
                 for (unsigned int i = 0; i < dofs_per_cell; ++i) {
@@ -2644,8 +2644,8 @@ namespace PlasticityLab {
 
           const auto inv_updated_F = invert(updated_F);
           const Number material_Jacobian = material.get_material_Jacobian(quadrature_point_index) / determinant(current_F);
-          const Number previous_Jacobian = determinant(current_F) * material_Jacobian;
-          const Number Jacobian = determinant(updated_F) * material_Jacobian;
+          [[maybe_unused]] const Number previous_Jacobian = determinant(current_F) * material_Jacobian;
+          [[maybe_unused]] const Number Jacobian = determinant(updated_F) * material_Jacobian;
 
           const Number radius = fe_values.quadrature_point(q_point)[0];
 
@@ -2796,7 +2796,7 @@ namespace PlasticityLab {
                 boundaryHeatSource = thermal_lbc_system.boundaryLoadAppliers.cbegin();
                 boundaryHeatSource != thermal_lbc_system.boundaryLoadAppliers.cend();
                 ++boundaryHeatSource) {
-            if (cell->face(face)->boundary_id() == boundaryHeatSource->first) {
+            if (cell->face(face)->boundary_id() == static_cast<types::boundary_id>(boundaryHeatSource->first)) {
               for (unsigned int i = 0; i < dofs_per_cell; ++i) {
                 for (unsigned int q_point = 0;
                      q_point < face_quadrature_formula.size();
@@ -2831,7 +2831,7 @@ namespace PlasticityLab {
                 convectionBC = thermal_lbc_system.convection_BC_appliers.cbegin();
                 convectionBC != thermal_lbc_system.convection_BC_appliers.cend();
                 ++convectionBC) {
-            if (cell->face(face)->boundary_id() == convectionBC->first) {
+            if (cell->face(face)->boundary_id() == static_cast<types::boundary_id>(convectionBC->first)) {
               for (unsigned int q_point = 0;
                    q_point < face_quadrature_formula.size();
                    ++q_point) {
@@ -2848,11 +2848,11 @@ namespace PlasticityLab {
                   (current_face_displacement_values[q_point][0]
                     + face_displacement_value_increments[q_point][0])/fe_mech_values.quadrature_point(q_point)[0]);
 
-                const Number J = determinant(updated_F);
+                [[maybe_unused]] const Number J = determinant(updated_F);
                 const Tensor<2, dim+1, Number> inv_deformation_gradient = invert(updated_F);
                 const Tensor<1, dim+1, Number> reference_normal = postprocess_tensor_dimension(mech_fe_face_values.normal_vector(q_point), 0);
                 const Tensor<1, dim+1, Number> F_inv_transpose_N = transpose(inv_deformation_gradient) * reference_normal;
-                const Number norm_F_inv_transpose_N = (F_inv_transpose_N).norm();
+                [[maybe_unused]] const Number norm_F_inv_transpose_N = (F_inv_transpose_N).norm();
 
                 const Number RJxW = fe_face_values.quadrature_point(q_point)[0] / material_area_factors.at(surface_point_key).norm() * fe_face_values.JxW(q_point);
 
@@ -2909,7 +2909,7 @@ namespace PlasticityLab {
   void PlasticityLabProg<dim, Number>::assemble_mesh_motion_system(
         NewtonStepSystem &mesh_motion_nonlinear_system,
         const DoFSystem<dim, Number> &mesh_motion_dof_system,
-        const LBCSystem<dim, Number, dim> &mesh_motion_lbc_system,
+        const LBCSystem<dim, Number, dim> &,
         const NewtonStepSystem &deformation_nonlinear_system,
         const DoFSystem<dim, Number> &deformation_dof_system,
         const DoFSystem<dim, Number> &mixed_fe_dof_system,
@@ -3086,7 +3086,7 @@ namespace PlasticityLab {
 
         for (unsigned int q_point = 0; q_point < n_q_points; ++q_point) {
 
-          const point_index_t quadrature_point_index = cell->user_index() + q_point;
+          [[maybe_unused]] const point_index_t quadrature_point_index = cell->user_index() + q_point;
 
           const Number cell_jacobian = determinant(static_cast<Tensor <2, dim, Number>>(mesh_motion_fe_values.jacobian(q_point)));
 
@@ -3106,7 +3106,7 @@ namespace PlasticityLab {
           const auto inv_mesh_motion_gradient = invert(mesh_motion_gradient);
           const auto inv_deformation_gradient = invert(deformation_gradient);
 
-          const Number deformation_Jacobian = determinant(deformation_gradient);
+          [[maybe_unused]] const Number deformation_Jacobian = determinant(deformation_gradient);
           const Number mesh_motion_Jacobian = determinant(mesh_motion_gradient);
 
           Number projected_jacobian = 0;
@@ -3494,7 +3494,7 @@ namespace PlasticityLab {
             (current_displacement_values[q_point][0]
               + displacement_value_increments[q_point][0])/fe_values.quadrature_point(q_point)[0]);
 
-          const auto inv_updated_F = invert(updated_F);
+          [[maybe_unused]] const auto inv_updated_F = invert(updated_F);
           const Number Jacobian = determinant(updated_F);
           const Number previous_Jacobian = determinant(current_F);
 

--- a/ALE_Finite_Strain_Plasticity/src/PlasticityLabProg.cpp
+++ b/ALE_Finite_Strain_Plasticity/src/PlasticityLabProg.cpp
@@ -577,7 +577,7 @@ namespace PlasticityLab {
 
       for (int i = 0; i < nprocesses; ++i) {
         MPI_Isend(
-          &local_state_parameter_groups.at(i)[0],
+          local_state_parameter_groups.at(i).data(),
           material_parameter_count * mapping_remote_reference_point_counts.at(i),
           MPI_DOUBLE, i, MATERIAL_STATE_PARAMETER,
           mpi_communicator,
@@ -586,7 +586,7 @@ namespace PlasticityLab {
 
       for (int i = 0; i < nprocesses; ++i) {
         MPI_Isend(
-          &local_deformation_gradient_groups.at(i)[0],
+          local_deformation_gradient_groups.at(i).data(),
           (dim+1) * (dim+1) * mapping_remote_reference_point_counts.at(i),
           MPI_DOUBLE, i, REMAPPED_DEFORMATION_GRADIENT,
           mpi_communicator,
@@ -597,14 +597,14 @@ namespace PlasticityLab {
         const unsigned int row_start = i + nprocesses * request_array_size;
 
         MPI_Irecv(
-          &remote_state_parameter_groups.at(i)[0],
+          remote_state_parameter_groups.at(i).data(),
           material_parameter_count * mapping_remote_remapped_point_counts.at(i),
           MPI_DOUBLE, i, MATERIAL_STATE_PARAMETER,
           mpi_communicator,
           &requests_vector[row_start + nprocesses * material_state_parameter_requests_offset]);
 
         MPI_Irecv(
-          &remote_deformation_gradient_groups.at(i)[0],
+          remote_deformation_gradient_groups.at(i).data(),
           (dim+1) * (dim+1) * mapping_remote_remapped_point_counts.at(i),
           MPI_DOUBLE, i, REMAPPED_DEFORMATION_GRADIENT,
           mpi_communicator,
@@ -909,7 +909,7 @@ namespace PlasticityLab {
 
       for (int i = 0; i < nprocesses; ++i) {
         MPI_Isend(
-          &local_previous_temperature_groups.at(i)[0],
+          local_previous_temperature_groups.at(i).data(),
           thermal_remote_reference_point_counts.at(i),
           MPI_DOUBLE, i, PREVIOUS_TEMPERATURE,
           mpi_communicator,
@@ -920,7 +920,7 @@ namespace PlasticityLab {
         const unsigned int row_start = i + nprocesses * request_array_size;
 
         MPI_Irecv(
-          &remote_previous_temperature_groups.at(i)[0],
+          remote_previous_temperature_groups.at(i).data(),
           thermal_remote_remapped_point_counts.at(i),
           MPI_DOUBLE, i, PREVIOUS_TEMPERATURE,
           mpi_communicator,
@@ -1330,21 +1330,21 @@ namespace PlasticityLab {
 
     for (int i = 0; i < nprocesses; ++i) {
       MPI_Isend(
-        &local_previous_deformation_groups.at(i)[0],
+        local_previous_deformation_groups.at(i).data(),
         (dim+1) * remote_reference_point_counts.at(i),
         MPI_DOUBLE, i, PREVIOUS_DEFORMATION,
         mpi_communicator,
         &requests_vector[i + nprocesses * previous_deformation_requests_offset]);
 
       MPI_Isend(
-        &local_previous_velocity_groups.at(i)[0],
+        local_previous_velocity_groups.at(i).data(),
         (dim+1) * remote_reference_point_counts.at(i),
         MPI_DOUBLE, i, PREVIOUS_VELOCITY,
         mpi_communicator,
         &requests_vector[i + nprocesses * previous_velocity_requests_offset]);
 
       MPI_Isend(
-        &local_previous_second_time_rate_groups.at(i)[0],
+        local_previous_second_time_rate_groups.at(i).data(),
         (dim+1) * remote_reference_point_counts.at(i),
         MPI_DOUBLE, i, PREVIOUS_SECOND_TIME_RATE,
         mpi_communicator,
@@ -1355,21 +1355,21 @@ namespace PlasticityLab {
       const unsigned int row_start = i + nprocesses * request_array_size;
 
       MPI_Irecv(
-        &remote_previous_deformation_groups.at(i)[0],
+        remote_previous_deformation_groups.at(i).data(),
         (dim+1) * remote_remapped_point_counts.at(i),
         MPI_DOUBLE, i, PREVIOUS_DEFORMATION,
         mpi_communicator,
         &requests_vector[row_start + nprocesses * previous_deformation_requests_offset]);
 
       MPI_Irecv(
-        &remote_previous_velocity_groups.at(i)[0],
+        remote_previous_velocity_groups.at(i).data(),
         (dim+1) * remote_remapped_point_counts.at(i),
         MPI_DOUBLE, i, PREVIOUS_VELOCITY,
         mpi_communicator,
         &requests_vector[row_start + nprocesses * previous_velocity_requests_offset]);
 
       MPI_Irecv(
-        &remote_previous_second_time_rate_groups.at(i)[0],
+        remote_previous_second_time_rate_groups.at(i).data(),
         (dim+1) * remote_remapped_point_counts.at(i),
         MPI_DOUBLE, i, PREVIOUS_SECOND_TIME_RATE,
         mpi_communicator,

--- a/ALE_Finite_Strain_Plasticity/src/PlasticityLabProg.h
+++ b/ALE_Finite_Strain_Plasticity/src/PlasticityLabProg.h
@@ -446,7 +446,7 @@ namespace PlasticityLab {
   };
 
   struct NewtonIterationDivergenceException : std::exception {
-    const char *what() const _GLIBCXX_USE_NOEXCEPT {
+    const char *what() const _GLIBCXX_USE_NOEXCEPT override {
       return "Newton step solution diverged!\n";
     }
   };

--- a/ALE_Finite_Strain_Plasticity/src/PlasticityLabProgDrivers.cpp
+++ b/ALE_Finite_Strain_Plasticity/src/PlasticityLabProgDrivers.cpp
@@ -87,14 +87,6 @@ namespace PlasticityLab {
       discontinuous_dof_system.locally_owned_dofs,
       mpi_communicator);
 
-    std::vector< MixedFEProjector<dim, Number> > mech_fe_projectors;
-
-    setup_mixed_fe_projection_data(
-      triangulation, mech_fe_projectors,
-      mech_fe, quadrature_formula);
-
-
-
     {
       TrilinosWrappers::MPI::Vector initial_velocity(
         mech_dof_system.locally_owned_dofs,
@@ -348,7 +340,7 @@ namespace PlasticityLab {
       if (clip_factor < 1.0) pcout << "clip factor: " << clip_factor << endl;
 
       pcout << "doing line search..." << endl;
-      bool hit_line_search_limit = false;
+      [[maybe_unused]] bool hit_line_search_limit = false;
       for (unsigned int i = 0; true/*i < 18*/; ++i) {
         const Number alpha = std::pow(0.5, static_cast<Number>(i));
         if (i > 5 && clip_factor * alpha * solution_norm < 1e-1) {
@@ -571,7 +563,7 @@ namespace PlasticityLab {
       if (clip_factor < 1.0) pcout << "clip factor: " << clip_factor << endl;
 
       pcout << "doing line search..." << endl;
-      bool hit_line_search_limit = false;
+      [[maybe_unused]] bool hit_line_search_limit = false;
       for (unsigned int i = 0; true/*i < 18*/; ++i) {
         const Number alpha = std::pow(0.5, static_cast<Number>(i));
         if (i > 5 && clip_factor * alpha * solution_norm < 1e-1) {
@@ -689,7 +681,7 @@ namespace PlasticityLab {
     LBCSystem<dim, Number, 1> &therm_lbc_system,
     int n_initial_global_refinements) {
 
-    const Number initial_velocity = 1.9e5; // [mm/s]
+    [[maybe_unused]] const Number initial_velocity = 1.9e5; // [mm/s]
     const Number height = 2.5*25.4; // [mm]
     const Number inner_radius = 12.5; // [mm]
     const Number radius = 12.5; // [mm]

--- a/ALE_Finite_Strain_Plasticity/src/PlasticityLabProgDrivers.cpp
+++ b/ALE_Finite_Strain_Plasticity/src/PlasticityLabProgDrivers.cpp
@@ -98,9 +98,10 @@ namespace PlasticityLab {
         initial_velocity_interpolation_handler->interpolate(initial_velocity, mech_dof_system);
       }
 
+      // Assigning the locally-owned vector into the ghosted vector performs
+      // the necessary ghost import; compress() must not be called on a
+      // vector that has ghost elements (it is read-only).
       mech_nonlinear_system.previous_time_derivative = initial_velocity;
-      mech_nonlinear_system.previous_time_derivative.compress(
-        VectorOperation::insert);
     }
 
 
@@ -116,8 +117,6 @@ namespace PlasticityLab {
       }
 
       mech_nonlinear_system.previous_deformation = initial_deformation;
-      mech_nonlinear_system.previous_deformation.compress(
-        VectorOperation::insert);
     }
 
 
@@ -197,8 +196,6 @@ namespace PlasticityLab {
         }
 
         mech_nonlinear_system.current_increment = step_increment;
-        mech_nonlinear_system.current_increment.compress(
-          VectorOperation::insert);
       }
 
       solve_mesh_motion_step(
@@ -267,10 +264,8 @@ namespace PlasticityLab {
 
       mech_nonlinear_system.advance_time(time_increment, rho_infty, true);
       therm_nonlinear_system.previous_deformation += therm_nonlinear_system.current_increment;
-      therm_nonlinear_system.previous_deformation.compress(VectorOperation::add);
 
       therm_nonlinear_system.current_increment = 0;
-      therm_nonlinear_system.current_increment.compress(VectorOperation::insert);
 
       pcout << "Next timestep..." << std::endl;
 
@@ -354,7 +349,6 @@ namespace PlasticityLab {
           temp_locally_owned_increment.sadd(1, -alpha * clip_factor, mech_nonlinear_system.Newton_step_solution);
           temp_locally_owned_increment.compress(VectorOperation::insert);
           mech_nonlinear_system.current_increment = temp_locally_owned_increment;
-          mech_nonlinear_system.current_increment.compress(VectorOperation::insert);
 
           try {
             assemble_mechanical_system(
@@ -400,7 +394,6 @@ namespace PlasticityLab {
           temp_locally_owned_increment.sadd(1, -2 * alpha * clip_factor, mech_nonlinear_system.Newton_step_solution);
           temp_locally_owned_increment.compress(VectorOperation::insert);
           mech_nonlinear_system.current_increment = temp_locally_owned_increment;
-          mech_nonlinear_system.current_increment.compress(VectorOperation::insert);
           break;
         }
         previous_residual = current_residual;
@@ -465,14 +458,11 @@ namespace PlasticityLab {
         for (unsigned int i = 0; i < (NewtonStep > 0 ? 6 : 1); ++i) {
           const Number alpha = std::pow(0.5, static_cast<Number>(i));
 
-          mech_nonlinear_system.current_increment.compress(VectorOperation::insert);
-
           temp_locally_owned_increment = full_step_increment;
           temp_locally_owned_increment.sadd(1, -alpha, therm_nonlinear_system.Newton_step_solution);
           therm_dof_system.nodal_constraints.distribute(temp_locally_owned_increment);
           temp_locally_owned_increment.compress(VectorOperation::insert);
           therm_nonlinear_system.current_increment = temp_locally_owned_increment;
-          therm_nonlinear_system.current_increment.compress(VectorOperation::insert);
 
           assemble_thermal_system(
             therm_nonlinear_system,
@@ -577,7 +567,6 @@ namespace PlasticityLab {
           temp_locally_owned_increment.sadd(1, -alpha * clip_factor, mesh_motion_nonlinear_system.Newton_step_solution);
           temp_locally_owned_increment.compress(VectorOperation::insert);
           mesh_motion_nonlinear_system.current_increment = temp_locally_owned_increment;
-          mesh_motion_nonlinear_system.current_increment.compress(VectorOperation::insert);
 
           try {
             assemble_mesh_motion_system(
@@ -620,7 +609,6 @@ namespace PlasticityLab {
           temp_locally_owned_increment.sadd(1, -2 * alpha * clip_factor, mesh_motion_nonlinear_system.Newton_step_solution);
           temp_locally_owned_increment.compress(VectorOperation::insert);
           mesh_motion_nonlinear_system.current_increment = temp_locally_owned_increment;
-          mesh_motion_nonlinear_system.current_increment.compress(VectorOperation::insert);
           break;
         }
         previous_residual = current_residual;

--- a/ALE_Finite_Strain_Plasticity/src/ScaleComponentFunction.h
+++ b/ALE_Finite_Strain_Plasticity/src/ScaleComponentFunction.h
@@ -24,7 +24,7 @@ namespace PlasticityLab {
       const unsigned int in_component=2,
       const unsigned int out_component=2);
     virtual ~ScaleComponentFunction();
-    virtual void vector_value(const Point<dim> &p, Vector<Number> &values) const;
+    virtual void vector_value(const Point<dim> &p, Vector<Number> &values) const override;
 
    private:
     Number scale_factor;
@@ -38,9 +38,9 @@ namespace PlasticityLab {
       const unsigned int in_component,
       const unsigned int out_component) :
   Function<dim, Number>(components),
+  scale_factor(scale_factor),
   in_component(in_component),
-  out_component(out_component),
-  scale_factor(scale_factor) { }
+  out_component(out_component) { }
 
   template<int dim, typename Number, int components>
   ScaleComponentFunction<dim, Number, components>::~ScaleComponentFunction() {}

--- a/ALE_Finite_Strain_Plasticity/src/ScaleZFunction.h
+++ b/ALE_Finite_Strain_Plasticity/src/ScaleZFunction.h
@@ -21,7 +21,7 @@ namespace PlasticityLab {
    public:
     ScaleZFunction(const Number scale_factor, const unsigned int component=2);
     virtual ~ScaleZFunction();
-    virtual void vector_value(const Point<dim> &p, Vector<Number> &values) const;
+    virtual void vector_value(const Point<dim> &p, Vector<Number> &values) const override;
 
    private:
     Number scale_factor;

--- a/ALE_Finite_Strain_Plasticity/src/ThermoPlasticMaterial.cpp
+++ b/ALE_Finite_Strain_Plasticity/src/ThermoPlasticMaterial.cpp
@@ -181,7 +181,7 @@ namespace PlasticityLab {
   inline void
   ThermoPlasticMaterial<dim, ViscoplasticYieldLaw, Number>::
   compute_pressure(ConstitutiveModelRequest<dim, Number> &constitutive_request,
-                   const point_index_t &point_index) {
+                   const point_index_t &) {
     const Number J = constitutive_request.get_deformation_Jacobian();
     const Number temperature = constitutive_request.get_temperature();
     if (J > 0) {
@@ -246,7 +246,7 @@ namespace PlasticityLab {
         determine_delta_gamma(delta_gamma, alpha_n_plus_1, norm_ksi_trial,
                               mu_bar, hardening_parameters.equivalent_plastic_strain, temperature,
                               time_increment, 1e-04, 300);
-      } catch(MaterialDomainException exc) {
+      } catch(const MaterialDomainException &exc) {
         std::cout << "isochoric_deformation_gradient: " << isochoric_deformation_gradient
                   << "\nb_e: " << b_e
                   << "\nb_e_bar_next: " << b_e_bar_next
@@ -273,7 +273,7 @@ namespace PlasticityLab {
                                delta_gamma,
                                time_increment,
                                temperature);
-      const Number d_y_alpha_d_alpha = viscoplastic_yield_law.hardening_alpha_derivatives(
+      [[maybe_unused]] const Number d_y_alpha_d_alpha = viscoplastic_yield_law.hardening_alpha_derivatives(
                                          DH_alpha_n_plus_1,
                                          DK_alpha_n_plus_1,
                                          alpha_n_plus_1,
@@ -324,7 +324,7 @@ namespace PlasticityLab {
             det_plastic_strain = determinant(b_e_bar);
           }
 
-          const Tensor<2, dim, Number> inverse_isochoric_deformation_gradient = invert(isochoric_deformation_gradient);
+          [[maybe_unused]] const Tensor<2, dim, Number> inverse_isochoric_deformation_gradient = invert(isochoric_deformation_gradient);
           material_point_history[point_index].plastic_strain = b_e_bar;
         }
       } /*if(update_stress_deviator & update_flags)*/
@@ -382,7 +382,7 @@ namespace PlasticityLab {
   void ThermoPlasticMaterial<dim, ViscoplasticYieldLaw, Number>::
   compute_heat_flux(
         ConstitutiveModelRequest<dim, Number> &constitutive_request,
-        const point_index_t &point_index) {
+        const point_index_t &) {
     const Tensor<1, dim, Number> thermal_gradient = constitutive_request.get_thermal_gradient();
     constitutive_request.set_heat_flux(thermal_conductivity * thermal_gradient);
     constitutive_request.set_heat_flux_tangent_moduli(thermal_conductivity * unit_symmetric_tensor<dim, Number>());
@@ -396,9 +396,9 @@ namespace PlasticityLab {
     const auto point_history = material_point_history.at(point_index);
     const Number J = constitutive_request.get_deformation_Jacobian();
     const Number previous_J = constitutive_request.get_previous_deformation_Jacobian();
-    const Number J_time_rate = constitutive_request.get_deformation_Jacobian_time_rate();
+    [[maybe_unused]] const Number J_time_rate = constitutive_request.get_deformation_Jacobian_time_rate();
     const Number theta = constitutive_request.get_temperature();
-    const Number previous_theta = constitutive_request.get_previous_temperature();
+    [[maybe_unused]] const Number previous_theta = constitutive_request.get_previous_temperature();
     const Number time_increment = constitutive_request.get_time_increment();
     if (J != 0 and previous_J != 0) {
       const Number eta = (3.0/1000.0) * kappa * thermal_expansion_coefficient * (J - 1.0/J);
@@ -416,7 +416,7 @@ namespace PlasticityLab {
   void ThermoPlasticMaterial<dim, ViscoplasticYieldLaw, Number>::
   compute_stored_heat_rate(
         ConstitutiveModelRequest<dim, Number> &constitutive_request,
-        const point_index_t &point_index) {
+        const point_index_t &) {
     const Number stored_heat_rate = heat_capacity * constitutive_request.get_temperature_time_rate();
     constitutive_request.set_stored_heat_rate(stored_heat_rate);
     constitutive_request.set_stored_heat_rate_tangent_modulus(heat_capacity);

--- a/ALE_Finite_Strain_Plasticity/src/ThermoPlasticMaterial.h
+++ b/ALE_Finite_Strain_Plasticity/src/ThermoPlasticMaterial.h
@@ -31,23 +31,23 @@ namespace PlasticityLab {
 
     void compute_constitutive_request(
       ConstitutiveModelRequest <dim, Number> &constitutive_request,
-      const point_index_t &point_index);
+      const point_index_t &point_index) override;
 
-    Number get_material_Jacobian(const point_index_t &point_index) const;
-    dealii::SymmetricTensor<2, dim, Number> get_plastic_strain(const point_index_t &point_index) const;
+    Number get_material_Jacobian(const point_index_t &point_index) const override;
+    dealii::SymmetricTensor<2, dim, Number> get_plastic_strain(const point_index_t &point_index) const override;
 
     std::vector<Number> get_state_parameters(
             const point_index_t &point_index,
-            const Tensor<2, dim, Number> &reference_transformation=unit_symmetric_tensor<dim>()) const;
+            const Tensor<2, dim, Number> &reference_transformation=unit_symmetric_tensor<dim>()) const override;
 
     void  set_state_parameters(
             const point_index_t &point_index,
             const std::vector<Number> &state_parameters,
-            const Tensor<2, dim, Number> &reference_transformation=unit_symmetric_tensor<dim>());
-    size_t get_material_parameter_count() const;
+            const Tensor<2, dim, Number> &reference_transformation=unit_symmetric_tensor<dim>()) override;
+    size_t get_material_parameter_count() const override;
 
 
-    void setup_point_history (const point_index_t point_count);
+    void setup_point_history (const point_index_t point_count) override;
 
    private:
     const Number kappa;

--- a/ALE_Finite_Strain_Plasticity/src/main.cpp
+++ b/ALE_Finite_Strain_Plasticity/src/main.cpp
@@ -104,7 +104,6 @@ getJohnsonCookThermoPlasticMaterial() {
          melting_temperature(1356), // [K]
          reference_temperature(293.15), // [K]
          reference_strain_rate(1.0), // [s^-1]
-         beta(1.0), //dimensionless
          thermal_expansion_coefficient(1.0e-5), // [K^-1]
          thermal_conductivity(4.5e-2), // [J/mm.K.s] // http://www.matweb.com/search/datasheet_print.aspx?matguid=193434cf42e343fab880e1dabdb143ba
          heat_capacity(3.588e-3), // cp*rho: [J.mm^-3.K^-1]

--- a/ALE_Finite_Strain_Plasticity/src/utilities.h
+++ b/ALE_Finite_Strain_Plasticity/src/utilities.h
@@ -6,10 +6,10 @@
 
 namespace PlasticityLab {
 
-  static MPI_Comm mpi_communicator(MPI_COMM_WORLD);
+  [[maybe_unused]] static MPI_Comm mpi_communicator(MPI_COMM_WORLD);
 
   struct NotImplementedException : std::exception {
-    const char *what() const _GLIBCXX_USE_NOEXCEPT {
+    const char *what() const _GLIBCXX_USE_NOEXCEPT override {
       return "Not Implemented.!\n";
     }
   };


### PR DESCRIPTION
## Summary

Fixes the assertion reported in #237 and makes the
`ALE_Finite_Strain_Plasticity` code-gallery example build warning-free and
run correctly (serial **and** parallel) against deal.II 9.7.

The example previously aborted immediately in Debug, and (once that was
resolved) hit two further latent, parallel-only failures. All are fixed
here across two commits.

## Correctness fixes

**1. `ComponentMask` size mismatch (the assertion from #237)**
`mech_fe` was declared as `FESystem(FE_Q, dim, FE_Q, 2)`, giving `dim+2`
components, while the rest of the program consistently assumes `dim+1`
(displacement + angular twist): the `ComponentMask`s,
`LBCSystem<dim, Number, dim+1>`, the `zero_function`, `Material<dim+1>`,
the `FEValuesExtractors` (displacements `0..dim-1`, angular velocity at
`dim`) and the output component names/interpretations. The extra
component made

    component_mask.represents_n_components(fe.n_components())

fail inside `VectorTools::interpolate_boundary_values()`. Changed the
multiplicity `2 -> 1` so the FE has `dim+1` components, matching
everything else.

**2. Singular `MixedFEProjector` over `mech_fe`**
Removed a dead projector setup whose result (`mech_fe_projectors`) was
never used. Building an L2 projector over the full `mech_fe` (12 dofs/cell
for Q1) from only 4 quadrature points yields a rank-deficient mass matrix,
which aborted in `FullMatrix::gauss_jordan()` once the `ComponentMask`
assertion was past.

**3. `compress()` on ghosted vectors (parallel abort)**
`previous_deformation`, `previous_time_derivative` and `current_increment`
carry ghost elements (reinit with `locally_relevant_dofs`) and are
read-only. The code assigned a locally-owned vector into them and then
called `compress()`, which 9.7 forbids
(`has_ghost_elements() == false`). Assigning owned -> ghosted already does
the ghost import, so these `compress()` calls were both unnecessary and
illegal, matching the existing pattern in
`NewtonStepSystem::advance_time()`. Removed the 11 offending calls; kept
`compress()` on locally-owned vectors.

**4. Out-of-bounds MPI buffer access in `remap_material_state_variables`
(parallel abort)**
The point-to-point exchange passed buffer addresses as
`&group.at(i)[0]`. When a rank exchanges no points with rank `i` that
buffer is empty, and `operator[](0)` on an empty `std::vector` aborts
under `_GLIBCXX_ASSERTIONS` (enabled in deal.II Debug). Replaced all 12
`&..._groups.at(i)[0]` buffer arguments with `.data()`, which is well
defined for empty vectors.

## Warning cleanup

Debug and Release now compile with **zero project warnings**:
- `-Wdeprecated-declarations`: use the returning form of
  `extract_locally_relevant_dofs()` and the two-index-set
  `AffineConstraints::reinit()`.
- `-Wsuggest-override`: added `override` to the `Material` /
  `Function` / `std::exception` overrides.
- `-Wreorder`: fixed member-init order in
  `BoundaryUnidirectionalPenaltySpec` and `ScaleComponentFunction`.
- `-Wsign-compare`: cast `boundary_id()` comparisons to
  `types::boundary_id`.
- `-Wcatch-value`: catch `MaterialDomainException` by const reference.
- `-Wunused-*`: tagged genuinely-unused locals/parameters
  `[[maybe_unused]]` (preserving computations), dropped an unused local,
  and elided unused parameter names in stub methods.

## Testing

- **Debug** and **Release** build with 0 errors / 0 project warnings
  (deal.II 9.7).
- `mpirun -n 4` and `mpirun -n 18` run the full nonlinear solve
  (mesh-motion -> mechanical Newton iterations -> contact) without aborting.

## Commits

- `ALE_Finite_Strain_Plasticity: fix ComponentMask assertion and clean up build`
- `ALE_Finite_Strain_Plasticity: fix parallel (MPI) runtime aborts`
