### PR TITLE
ALE_Finite_Strain_Plasticity: fix MPI aborts from writing into ghosted vectors

### DIFF
--- a/ALE_Finite_Strain_Plasticity/src/NewtonStepSystem.h
+++ b/ALE_Finite_Strain_Plasticity/src/NewtonStepSystem.h
@@ -122,21 +122,40 @@ namespace PlasticityLab {
 
       }
       
-      // Update the deformation vector with the computed
-      // increment. Because 'previous_deformation' is a vector with
-      // ghost entries, it is a read-only vector and we cannot write
-      // into it -- so we have to create a temporary vector first and
-      // only copy it at the end:
-      {
-        _locally_owned_previous_deformation = previous_deformation;
-        _locally_owned_current_increment    = current_increment;
-        _locally_owned_previous_deformation += _locally_owned_current_increment;
-        previous_deformation = _locally_owned_previous_deformation;
-      }
+      // Update the deformation vector with the computed increment.
+      add_current_increment_to_previous_deformation();
 
       if(reset_increment) {
         current_increment = 0;
       }
+    }
+
+    // Add the current Newton increment into the deformation vector, i.e.
+    // compute previous_deformation += current_increment.
+    //
+    // 'previous_deformation' is a vector with ghost entries and therefore
+    // read-only: we are not allowed to write into it (with the exception of
+    // setting it to zero). We therefore carry out the arithmetic in
+    // fully-distributed (locally-owned) temporary vectors and only assign the
+    // result back into the ghosted vector at the very end; that assignment
+    // performs the necessary ghost-value communication.
+    void add_current_increment_to_previous_deformation() {
+      _locally_owned_previous_deformation = previous_deformation;
+      _locally_owned_current_increment    = current_increment;
+      _locally_owned_previous_deformation += _locally_owned_current_increment;
+      previous_deformation = _locally_owned_previous_deformation;
+    }
+
+    // Set the deformation vector to the negative of the current increment,
+    // i.e. compute previous_deformation = -current_increment.
+    //
+    // As above, 'previous_deformation' is a ghosted, read-only vector, so the
+    // negation is performed in a fully-distributed temporary and only the
+    // result is assigned back into the ghosted vector.
+    void set_previous_deformation_to_negative_current_increment() {
+      _locally_owned_current_increment = current_increment;
+      _locally_owned_current_increment *= -1;
+      previous_deformation = _locally_owned_current_increment;
     }
 
     TrilinosWrappers::SparseMatrix  Newton_step_matrix;

--- a/ALE_Finite_Strain_Plasticity/src/NewtonStepSystem.h
+++ b/ALE_Finite_Strain_Plasticity/src/NewtonStepSystem.h
@@ -41,20 +41,31 @@ namespace PlasticityLab {
         dof_system.locally_owned_dofs,
         mpi_communicator);
       current_increment.reinit(
+        dof_system.locally_owned_dofs,
         dof_system.locally_relevant_dofs,
         mpi_communicator);
       Newton_step_residual.reinit(
         dof_system.locally_owned_dofs,
         mpi_communicator);
       previous_deformation.reinit(
+        dof_system.locally_owned_dofs,
         dof_system.locally_relevant_dofs,
         mpi_communicator);
 
       previous_time_derivative.reinit(
+        dof_system.locally_owned_dofs,
         dof_system.locally_relevant_dofs,
         mpi_communicator);
       previous_second_time_derivative.reinit(
+        dof_system.locally_owned_dofs,
         dof_system.locally_relevant_dofs,
+        mpi_communicator);
+
+      _locally_owned_current_increment.reinit(
+        dof_system.locally_owned_dofs,
+        mpi_communicator);
+      _locally_owned_previous_deformation.reinit(
+        dof_system.locally_owned_dofs,
         mpi_communicator);
 
       _locally_owned_previous_time_derivative.reinit(
@@ -110,7 +121,19 @@ namespace PlasticityLab {
         previous_second_time_derivative = _locally_owned_previous_second_time_derivative;
 
       }
-      previous_deformation += current_increment;
+      
+      // Update the deformation vector with the computed
+      // increment. Because 'previous_deformation' is a vector with
+      // ghost entries, it is a read-only vector and we cannot write
+      // into it -- so we have to create a temporary vector first and
+      // only copy it at the end:
+      {
+        _locally_owned_previous_deformation = previous_deformation;
+        _locally_owned_current_increment    = current_increment;
+        _locally_owned_previous_deformation += _locally_owned_current_increment;
+        previous_deformation = _locally_owned_previous_deformation;
+      }
+
       if(reset_increment) {
         current_increment = 0;
       }
@@ -125,9 +148,10 @@ namespace PlasticityLab {
     TrilinosWrappers::MPI::Vector   previous_time_derivative;
     TrilinosWrappers::MPI::Vector   previous_second_time_derivative;
 
+    TrilinosWrappers::MPI::Vector   _locally_owned_previous_deformation;
+    TrilinosWrappers::MPI::Vector   _locally_owned_current_increment;
     TrilinosWrappers::MPI::Vector   _locally_owned_previous_time_derivative;
     TrilinosWrappers::MPI::Vector   _locally_owned_previous_second_time_derivative;
-
   };
 
 } /* namespace PlasticityLab */

--- a/ALE_Finite_Strain_Plasticity/src/PlasticityLabProgDrivers.cpp
+++ b/ALE_Finite_Strain_Plasticity/src/PlasticityLabProgDrivers.cpp
@@ -50,7 +50,19 @@ namespace PlasticityLab {
     therm_lbc_system.apply_constraints(therm_dof_system);
     therm_nonlinear_system.setup(therm_dof_system);
 
-    therm_nonlinear_system.previous_deformation = ambient_temperature;
+    // Initialize the temperature solution vector. Because we are
+    // initializing with a possibly non-zero value, we can't just
+    // assign that value to the vector in a parallel setting because
+    // the solution vector has ghost entries and so is
+    // read-only. Rather, we create a completely distributed vector,
+    // assign the value to it, and then copy that into the solution
+    // vector.
+    {
+      TrilinosWrappers::MPI::Vector tmp (therm_dof_system.locally_owned_dofs,
+                                         mpi_communicator);
+      tmp = ambient_temperature;
+      therm_nonlinear_system.previous_deformation = tmp;
+    }
 
     mixed_fe_dof_system.setup_dof_system(mixed_var_fe);
 

--- a/ALE_Finite_Strain_Plasticity/src/PlasticityLabProgDrivers.cpp
+++ b/ALE_Finite_Strain_Plasticity/src/PlasticityLabProgDrivers.cpp
@@ -221,8 +221,11 @@ namespace PlasticityLab {
         timeStep);
 
       mesh_motion_nonlinear_system.advance_time(time_increment, rho_infty, false);
-      mesh_motion_nonlinear_system.previous_deformation = mesh_motion_nonlinear_system.current_increment;
-      mesh_motion_nonlinear_system.previous_deformation *= -1;
+      // The mesh-motion deformation is the negative of the just-computed
+      // increment. 'previous_deformation' is a ghosted (read-only) vector, so
+      // this negation is delegated to the nonlinear system, which performs the
+      // arithmetic in fully-distributed temporaries.
+      mesh_motion_nonlinear_system.set_previous_deformation_to_negative_current_increment();
 
       std::unordered_map<point_index_t, Tensor<2, dim+1, Number>> remapped_deformation_gradients;
       remap_material_state_variables(
@@ -275,7 +278,10 @@ namespace PlasticityLab {
         true);
 
       mech_nonlinear_system.advance_time(time_increment, rho_infty, true);
-      therm_nonlinear_system.previous_deformation += therm_nonlinear_system.current_increment;
+      // Accumulate the thermal increment into the (ghosted, read-only)
+      // temperature field. The nonlinear system performs the addition in
+      // fully-distributed temporaries and assigns the result back.
+      therm_nonlinear_system.add_current_increment_to_previous_deformation();
 
       therm_nonlinear_system.current_increment = 0;
 


### PR DESCRIPTION
## Summary

Under MPI, the ALE_Finite_Strain_Plasticity example aborted during time
stepping with the deal.II assertion `!has_ghost_elements()`. The cause was
several places that wrote arithmetic results directly into
`previous_deformation`, which is a vector with ghost entries and therefore
read-only.

This PR fixes all such writes so the example builds cleanly and runs to
completion under MPI.

## Changes

- **Fix two places where we modify a ghosted vector** (6c6caa3): initial
  fix for the ghosted-vector writes surfaced by the assertion.
- **Fix remaining ghosted-vector writes** (b135642): two further writes into
  `previous_deformation` remained:
  - `mesh_motion`: `previous_deformation = current_increment; *= -1;`
  - `thermal`:     `previous_deformation += current_increment;`

  Both are now expressed as named `NewtonStepSystem` member functions
  (`add_current_increment_to_previous_deformation()` and
  `set_previous_deformation_to_negative_current_increment()`) that perform the
  arithmetic in fully-distributed temporary vectors and only assign the result
  back into the ghosted vector, which triggers the ghost-value communication.
  `advance_time()` reuses the first of these, removing a duplicated update block.

## Verification

Builds cleanly and runs to completion (all 80 time steps) under
`mpirun -np 2` with no ghost-element assertions.
