### PR TITLE
CI: Build on noble and drop jammy. Also build master on resolute.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -83,9 +83,15 @@ jobs:
       - name: Test coupled_laplace_problem
         run: |
           cd coupled_laplace_problem
-          (./coupled_laplace_problem 2>&1 & ./fancy_boundary_condition >fbc.log)
+          ./coupled_laplace_problem &
+          pid=$!
+          ./fancy_boundary_condition
+          wait "$pid"
           sed -i '2d' solution-10.vtk
-          numdiff solution-10.vtk test_data/reference-10.vtk || (echo "error_test=coupled_laplace_problem/" >> $GITHUB_ENV && exit 1)
+          numdiff solution-10.vtk test_data/reference-10.vtk || {
+            echo "error_test=coupled_laplace_problem/" >> $GITHUB_ENV
+            exit 1
+          }
 
       - name: Create issue about failure
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,11 +24,11 @@ jobs:
       matrix:
         build_type: ["Debug"]
         dealii_version: ["master", "v9.7.1", "v9.6.0"]
-        ubuntu_version: ["jammy"]
+        ubuntu_version: ["noble"]
         include:
           - build_type: "Debug"
             dealii_version: "master"
-            ubuntu_version: "noble"
+            ubuntu_version: "resolute"
 
     container:
       image: dealii/dealii:${{ matrix.dealii_version }}-${{ matrix.ubuntu_version }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install preCICE
         run: |
-          wget -O libprecice.deb https://github.com/precice/precice/releases/download/v3.2.0/libprecice3_3.2.0_${{ matrix.ubuntu_version }}.deb
+          wget -O libprecice.deb https://github.com/precice/precice/releases/download/v3.4.1/libprecice3_3.4.1_${{ matrix.ubuntu_version }}.deb
           apt-get -y install ./libprecice.deb
 
       - name: Install XBraid

--- a/coupled_laplace_problem/coupled_laplace_problem.cc
+++ b/coupled_laplace_problem/coupled_laplace_problem.cc
@@ -212,8 +212,8 @@ Adapter<dim, ParameterClass>::initialize(
   interface_nodes_ids.resize(n_interface_nodes);
 
   // The node location is obtained using `map_dofs_to_support_points()`.
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(mapping, dof_handler, support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(mapping, dof_handler);
 
   // `support_points` contains now the coordinates of all DoFs. In the next
   // step, the relevant coordinates are extracted using the IndexSet with the


### PR DESCRIPTION
This PR updates the github actions workflows to use noble, and we will also build the master image on resolute. This patch will drop the checks for jammy to be mindful regarding github actions resources.

I had to update libprecice as only version >=3.4.0 provides packages for resolute.

Further, I fixed a code gallery program because of https://github.com/dealii/dealii/pull/20082.